### PR TITLE
Fix package discovery configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Douglas Contributors", email = "contributors@example.com" }
 ]
-license = { file = "LICENSE" }
+license = "MIT"
 dependencies = [
     "typer",
     "pyyaml",
@@ -22,3 +22,7 @@ dev = [
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["douglas*"]
+exclude = ["tests", "tests.*", "examples", "examples.*", "templates", "templates.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,3 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["douglas*"]
-exclude = ["tests", "tests.*", "examples", "examples.*", "templates", "templates.*"]


### PR DESCRIPTION
## Summary
- configure setuptools package discovery to include only the douglas packages so editable installs ignore the templates folder
- declare the project license as an SPDX string to silence new setuptools warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea3bd27b88326bf961edbf9ce420d