### PR TITLE
Add review step using LLM feedback

### DIFF
--- a/douglas.yaml
+++ b/douglas.yaml
@@ -7,32 +7,49 @@ ai:
   provider: "openai"
   model: "gpt-4"
   prompt: "system_prompt.md"
+cadence:
+  Developer:
+    development: daily
+    quality_checks: daily
+    code_review: per_feature
+    retrospective: per_sprint
+  Tester:
+    test_cases: daily
+    regression: per_sprint
+  ProductOwner:
+    backlog_refinement: per_sprint
+    sprint_review: per_sprint
+  ScrumMaster:
+    daily_standup: daily
+    retrospective: per_sprint
+  DevOps:
+    release: per_feature
 loop:
   steps:
     - name: generate
-      cadence:
-        frequency: daily
+      role: Developer
+      activity: development
     - name: lint
-      cadence:
-        frequency: daily
+      role: Developer
+      activity: quality_checks
     - name: typecheck
-      cadence:
-        frequency: daily
+      role: Developer
+      activity: quality_checks
     - name: test
-      cadence:
-        frequency: daily
+      role: Tester
+      activity: test_cases
     - name: review
-      cadence:
-        frequency: per_feature
+      role: Developer
+      activity: code_review
     - name: commit
-      cadence:
-        frequency: daily
+      role: Developer
+      activity: development
     - name: push
-      cadence:
-        frequency: per_feature
+      role: DevOps
+      activity: release
     - name: pr
-      cadence:
-        frequency: per_feature
+      role: Developer
+      activity: code_review
   exit_conditions:
     - "ci_pass"
 push_policy: per_feature

--- a/douglas.yaml
+++ b/douglas.yaml
@@ -9,15 +9,35 @@ ai:
   prompt: "system_prompt.md"
 loop:
   steps:
-    - generate
-    - lint
-    - typecheck
-    - test
-    - review
-    - commit
-    - pr
+    - name: generate
+      cadence:
+        frequency: daily
+    - name: lint
+      cadence:
+        frequency: daily
+    - name: typecheck
+      cadence:
+        frequency: daily
+    - name: test
+      cadence:
+        frequency: daily
+    - name: review
+      cadence:
+        frequency: per_feature
+    - name: commit
+      cadence:
+        frequency: daily
+    - name: push
+      cadence:
+        frequency: per_feature
+    - name: pr
+      cadence:
+        frequency: per_feature
   exit_conditions:
     - "tests_pass"
+push_policy: per_feature
+sprint:
+  length_days: 10
 vcs:
   default_branch: "main"
   conventional_commits: true

--- a/douglas.yaml
+++ b/douglas.yaml
@@ -34,7 +34,7 @@ loop:
       cadence:
         frequency: per_feature
   exit_conditions:
-    - "tests_pass"
+    - "ci_pass"
 push_policy: per_feature
 sprint:
   length_days: 10

--- a/douglas/__init__.py
+++ b/douglas/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for Douglas."""
+
+__all__ = []

--- a/douglas/cadence_manager.py
+++ b/douglas/cadence_manager.py
@@ -1,0 +1,196 @@
+"""Cadence management utilities for role-based scheduling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+
+from douglas.sprint_manager import CadenceDecision
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checking
+    from douglas.sprint_manager import SprintManager
+
+
+@dataclass
+class CadenceContext:
+    """Snapshot of cadence state for a specific loop step."""
+
+    step_name: str
+    role: str
+    activity: str
+    cadence_value: Optional[object]
+    cadence_source: str
+    sprint_manager: "SprintManager"
+    sprint_day: int
+    sprint_length: int
+    run_count: int
+    per_sprint_consumed: int
+    available_events: Dict[str, int]
+    decision: Optional[CadenceDecision] = None
+
+
+def should_run_step(role: str, activity: str, context: CadenceContext) -> bool:
+    """Evaluate whether a step should run for the provided role and activity."""
+
+    decision = context.sprint_manager.should_run_step(
+        context.step_name, context.cadence_value
+    )
+
+    # When cadence is configured at the role level, surface the role/activity in logs.
+    if context.cadence_source == "role":
+        prefix = f"{role} cadence for {activity}"
+        message = decision.reason or ""
+        if decision.should_run:
+            reason = message or "eligible for this iteration."
+            decision = CadenceDecision(True, f"{prefix}: {reason}", decision.event_type)
+        else:
+            reason = message or "defers execution until the schedule permits."
+            decision = CadenceDecision(
+                False, f"{prefix} defers execution: {reason}", decision.event_type
+            )
+
+    # Record the decision for callers and tests.
+    context.decision = decision
+    return decision.should_run
+
+
+class CadenceManager:
+    """Determines when steps execute based on role-aware cadence rules."""
+
+    _DEFAULT_STEP_METADATA: Dict[str, Tuple[str, str]] = {
+        "generate": ("Developer", "development"),
+        "lint": ("Developer", "quality_checks"),
+        "typecheck": ("Developer", "quality_checks"),
+        "test": ("Tester", "test_cases"),
+        "review": ("Developer", "code_review"),
+        "feature_refinement": ("ProductOwner", "backlog_refinement"),
+        "refine": ("ProductOwner", "backlog_refinement"),
+        "demo": ("ProductOwner", "sprint_review"),
+        "retrospective": ("ScrumMaster", "retrospective"),
+        "commit": ("Developer", "development"),
+        "push": ("DevOps", "release"),
+        "pr": ("Developer", "code_review"),
+        "deploy": ("DevOps", "release"),
+    }
+
+    def __init__(
+        self,
+        cadence_config: Optional[Dict[str, Any]],
+        sprint_manager: "SprintManager",
+    ) -> None:
+        self._raw_config = cadence_config or {}
+        self._cadence_map = self._normalize_config(self._raw_config)
+        self.sprint_manager = sprint_manager
+        self.last_context: Optional[CadenceContext] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def evaluate_step(self, step_name: str, step_config: Dict[str, Any]) -> CadenceDecision:
+        """Return the cadence decision for a loop step."""
+
+        role, activity = self._resolve_role_activity(step_name, step_config)
+
+        cadence_override = step_config.get("cadence")
+        cadence_source = "step" if cadence_override is not None else "default"
+        cadence_value = cadence_override
+
+        if cadence_value is None:
+            cadence_value = self._lookup_role_cadence(role, activity)
+            if cadence_value is not None:
+                cadence_source = "role"
+
+        context = self._build_context(step_name, role, activity, cadence_value, cadence_source)
+        self.last_context = context
+
+        should_execute = should_run_step(role, activity, context)
+        decision = context.decision
+
+        if decision is None:
+            decision = self.sprint_manager.should_run_step(step_name, cadence_value)
+            context.decision = decision
+
+        if not should_execute:
+            return decision
+
+        return decision
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_role_activity(
+        self, step_name: str, step_config: Dict[str, Any]
+    ) -> Tuple[str, str]:
+        role = step_config.get("role")
+        activity = step_config.get("activity")
+
+        if role and activity:
+            return str(role), str(activity)
+
+        default_role, default_activity = self._DEFAULT_STEP_METADATA.get(
+            step_name.lower(), ("Developer", step_name)
+        )
+
+        return str(role or default_role), str(activity or default_activity)
+
+    def _lookup_role_cadence(self, role: str, activity: str) -> Optional[object]:
+        role_key = self._normalize_key(role)
+        activity_key = self._normalize_key(activity)
+        return self._cadence_map.get(role_key, {}).get(activity_key)
+
+    def _normalize_config(self, config: Dict[str, Any]) -> Dict[str, Dict[str, object]]:
+        normalized: Dict[str, Dict[str, object]] = {}
+        for role, activities in (config or {}).items():
+            if not isinstance(activities, dict):
+                continue
+            role_key = self._normalize_key(role)
+            if not role_key:
+                continue
+            normalized.setdefault(role_key, {})
+            for activity, value in activities.items():
+                activity_key = self._normalize_key(activity)
+                if not activity_key:
+                    continue
+                normalized[role_key][activity_key] = value
+        return normalized
+
+    def _build_context(
+        self,
+        step_name: str,
+        role: str,
+        activity: str,
+        cadence_value: Optional[object],
+        cadence_source: str,
+    ) -> CadenceContext:
+        available_events: Dict[str, int] = {}
+        for event in ("feature", "bug", "epic"):
+            pending = self.sprint_manager.pending_events.get(event, 0)
+            consumed = self.sprint_manager.event_consumption[step_name][event]
+            remaining = pending - consumed
+            available_events[event] = remaining if remaining > 0 else 0
+
+        per_sprint_consumed = self.sprint_manager.event_consumption[step_name]["sprint"]
+        run_count = self.sprint_manager.step_run_counts.get(step_name, 0)
+
+        return CadenceContext(
+            step_name=step_name,
+            role=role,
+            activity=activity,
+            cadence_value=cadence_value,
+            cadence_source=cadence_source,
+            sprint_manager=self.sprint_manager,
+            sprint_day=self.sprint_manager.current_day,
+            sprint_length=self.sprint_manager.sprint_length_days,
+            run_count=run_count,
+            per_sprint_consumed=per_sprint_consumed,
+            available_events=available_events,
+        )
+
+    @staticmethod
+    def _normalize_key(value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip().lower()
+
+
+__all__ = ["CadenceContext", "CadenceManager", "should_run_step"]

--- a/douglas/core.py
+++ b/douglas/core.py
@@ -1539,7 +1539,12 @@ class Douglas:
         diff_text = result.stdout
         max_length = 20000
         if len(diff_text) > max_length:
-            truncated = diff_text[:max_length]
+            # Truncate at the last complete line before max_length
+            last_newline = diff_text.rfind('\n', 0, max_length)
+            if last_newline != -1:
+                truncated = diff_text[:last_newline]
+            else:
+                truncated = diff_text[:max_length]
             truncated += "\n... (diff truncated)"
             return truncated
         return diff_text

--- a/douglas/core.py
+++ b/douglas/core.py
@@ -1,14 +1,19 @@
-import yaml
+import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
+
+import yaml
 
 from douglas.providers.llm_provider import LLMProvider
 from douglas.pipelines import lint, typecheck, test as testpipe
 
 class Douglas:
     def __init__(self, config_path='douglas.yaml'):
-        self.config = self.load_config(config_path)
+        self.config_path = Path(config_path)
+        self.config = self.load_config(self.config_path)
+        self.project_root = self.config_path.resolve().parent
         self.project_name = self.config.get('project', {}).get('name', '')
         self.lm_provider = self.create_llm_provider()
 
@@ -34,22 +39,539 @@ class Douglas:
         for step in steps:
             if step == 'generate':
                 print("Running generate step...")
-                # Placeholder: Invoke LLM generation (not implemented in first commit)
-                _ = self.lm_provider.generate_code("""# TODO: describe the task here""")
+                self.generate()
                 continue
             elif step == 'lint':
                 print("Running lint step...")
-                lint.run_lint()
+                try:
+                    lint.run_lint()
+                except SystemExit as exc:
+                    if exc.code not in (None, 0):
+                        print("Lint step failed; aborting remaining steps.")
+                    raise
             elif step == 'typecheck':
                 print("Running typecheck step...")
                 typecheck.run_typecheck()
             elif step == 'test':
                 print("Running test step...")
                 testpipe.run_tests()
+            elif step == 'review':
+                print("Running review step...")
+                self.review()
             else:
                 print(f"Unknown step '{step}'; skipping.")
         print("Douglas loop completed.")
         # In later versions, commit/push/PR steps would follow.
+
+    def generate(self):
+        prompt = self._build_generation_prompt()
+        if not prompt:
+            print("No prompt constructed for generation step; skipping.")
+            return
+
+        print("Invoking language model to propose code changes...")
+        try:
+            llm_output = self.lm_provider.generate_code(prompt)
+        except Exception as exc:
+            print(f"Error while invoking language model: {exc}")
+            return
+
+        if not llm_output or not llm_output.strip():
+            print("Language model returned an empty response; no changes applied.")
+            return
+
+        applied_paths = self._apply_llm_output(llm_output)
+        if applied_paths:
+            self._stage_changes(applied_paths)
+        else:
+            print("Model output did not yield any actionable changes.")
+
+    def review(self):
+        diff_text = self._get_pending_diff()
+        if not diff_text:
+            print("No code changes detected for review; skipping.")
+            return
+
+        prompt = self._build_review_prompt(diff_text)
+        if not prompt:
+            print("Unable to construct review prompt; skipping review step.")
+            return
+
+        print("Requesting language model review of recent changes...")
+        try:
+            feedback = self.lm_provider.generate_code(prompt)
+        except Exception as exc:
+            print(f"Error while invoking language model for review: {exc}")
+            return
+
+        if not feedback or not feedback.strip():
+            print("Language model returned empty review feedback.")
+            return
+
+        self._record_review_feedback(feedback)
+
+    def _build_generation_prompt(self):
+        sections = []
+
+        system_prompt = self._read_system_prompt()
+        if system_prompt:
+            sections.append(f"SYSTEM PROMPT:\n{system_prompt.strip()}")
+
+        project_cfg = self.config.get('project', {})
+        metadata_lines = []
+        if self.project_name:
+            metadata_lines.append(f"Name: {self.project_name}")
+        description = project_cfg.get('description')
+        if description:
+            metadata_lines.append(f"Description: {description}")
+        language = project_cfg.get('language')
+        if language:
+            metadata_lines.append(f"Primary language: {language}")
+        license_name = project_cfg.get('license')
+        if license_name:
+            metadata_lines.append(f"License: {license_name}")
+        if metadata_lines:
+            sections.append("PROJECT METADATA:\n" + "\n".join(metadata_lines))
+
+        commit_history = self._get_recent_commits()
+        if commit_history:
+            sections.append("RECENT COMMITS:\n" + commit_history)
+
+        working_tree_status = self._get_git_status()
+        if working_tree_status:
+            sections.append("WORKING TREE STATUS:\n" + working_tree_status)
+
+        open_tasks = self._collect_open_tasks()
+        if open_tasks:
+            sections.append("OPEN TASKS / TODOS:\n" + "\n".join(open_tasks))
+
+        instructions = (
+            "TASK:\nUsing the context above, determine the next meaningful code changes. Respond with either a "
+            "unified diff (starting with 'diff --git') that can be applied with `git apply`, or with one or more "
+            "fenced code blocks formatted as ```path/to/file.ext\\n<complete file contents>\\n```.\n"
+            "Avoid extra commentary outside the provided diffs or code blocks."
+        )
+        sections.append(instructions)
+
+        return "\n\n".join(section for section in sections if section).strip()
+
+    def _build_review_prompt(self, diff_text):
+        sections = []
+
+        system_prompt = self._read_system_prompt()
+        if system_prompt:
+            sections.append(f"SYSTEM PROMPT:\n{system_prompt.strip()}")
+
+        project_cfg = self.config.get('project', {})
+        metadata_lines = []
+        name = project_cfg.get('name')
+        if name:
+            metadata_lines.append(f"Project: {name}")
+        language = project_cfg.get('language')
+        if language:
+            metadata_lines.append(f"Primary language: {language}")
+        if metadata_lines:
+            sections.append("PROJECT CONTEXT:\n" + "\n".join(metadata_lines))
+
+        working_tree_status = self._get_git_status()
+        if working_tree_status:
+            sections.append("CURRENT STATUS:\n" + working_tree_status)
+
+        instructions = (
+            "TASK:\nYou are acting as a meticulous code reviewer."
+            " Examine the pending changes below and identify potential bugs,"
+            " risky assumptions, missing tests, or style issues. Provide"
+            " actionable suggestions in bullet form."
+        )
+        sections.append(instructions)
+
+        sections.append("CHANGES TO REVIEW:\n" + diff_text.strip())
+
+        return "\n\n".join(section for section in sections if section).strip()
+
+    def _read_system_prompt(self):
+        prompt_path_config = self.config.get('ai', {}).get('prompt')
+        if not prompt_path_config:
+            return ""
+
+        prompt_path = Path(prompt_path_config)
+        if not prompt_path.is_absolute():
+            prompt_path = (self.project_root / prompt_path).resolve()
+        try:
+            return prompt_path.read_text(encoding='utf-8')
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"Warning: Unable to read system prompt '{prompt_path}': {exc}")
+            return ""
+
+    def _get_recent_commits(self, limit=5):
+        try:
+            result = subprocess.run(
+                ['git', 'log', f'-{limit}', '--pretty=format:%h %s'],
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"Warning: Unable to retrieve recent commits: {exc}")
+            return ""
+
+    def _get_git_status(self):
+        try:
+            result = subprocess.run(
+                ['git', 'status', '--short'],
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return result.stdout.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"Warning: Unable to determine git status: {exc}")
+            return ""
+
+    def _collect_open_tasks(self, limit=5):
+        todos = []
+        skip_dirs = {
+            '.git',
+            '.hg',
+            '.svn',
+            '.venv',
+            'venv',
+            '__pycache__',
+            'node_modules',
+            '.mypy_cache',
+            '.pytest_cache',
+            'dist',
+            'build',
+        }
+        allowed_suffixes = {
+            '.py',
+            '.md',
+            '.txt',
+            '.rst',
+            '.js',
+            '.ts',
+            '.tsx',
+            '.jsx',
+            '.json',
+            '.yaml',
+            '.yml',
+            '.toml',
+            '.ini',
+            '.cfg',
+        }
+        try:
+            for path in self.project_root.rglob('*'):
+                if len(todos) >= limit:
+                    break
+                if path.is_dir():
+                    continue
+                if any(part in skip_dirs for part in path.parts):
+                    continue
+                suffix = path.suffix.lower()
+                if suffix and suffix not in allowed_suffixes:
+                    continue
+                if not suffix and path.name not in {'Dockerfile', 'Makefile'}:
+                    continue
+                try:
+                    content = path.read_text(encoding='utf-8')
+                except (UnicodeDecodeError, OSError):
+                    continue
+                for idx, line in enumerate(content.splitlines()):
+                    if 'TODO' in line or 'todo' in line:
+                        todos.append(f"{path.relative_to(self.project_root)}:{idx + 1} {line.strip()}")
+                        if len(todos) >= limit:
+                            break
+        except OSError:
+            return []
+        return todos
+
+    def _apply_llm_output(self, output):
+        if not output:
+            return set()
+
+        applied_paths = set()
+        diff_applied = False
+
+        for diff_text in self._extract_diff_candidates(output):
+            paths = self._apply_diff(diff_text)
+            if paths:
+                applied_paths.update(paths)
+                diff_applied = True
+
+        if diff_applied:
+            return applied_paths
+
+        code_block_paths = self._apply_code_blocks(output)
+        if code_block_paths:
+            applied_paths.update(code_block_paths)
+
+        return applied_paths
+
+    def _extract_diff_candidates(self, output):
+        candidates = []
+        stripped = output.strip()
+        if stripped and ('diff --git' in stripped or stripped.startswith('--- ')):
+            candidates.append(stripped)
+
+        pattern = re.compile(r"```(?P<header>[^\n]*)\n(?P<body>.*?)```", re.DOTALL)
+        for match in pattern.finditer(output):
+            header = match.group('header').strip().lower()
+            body = match.group('body').strip()
+            if not body:
+                continue
+            if header in {'diff', 'patch'} or 'diff --git' in body or body.startswith('--- '):
+                candidates.append(body)
+
+        unique_candidates = []
+        seen = set()
+        for candidate in candidates:
+            if candidate not in seen:
+                unique_candidates.append(candidate)
+                seen.add(candidate)
+        return unique_candidates
+
+    def _apply_diff(self, diff_text):
+        if 'diff --git' not in diff_text and not diff_text.lstrip().startswith('--- '):
+            return set()
+
+        if not diff_text.endswith('\n'):
+            diff_text += '\n'
+
+        try:
+            result = subprocess.run(
+                ['git', 'apply', '--whitespace=nowarn', '-'],
+                cwd=self.project_root,
+                input=diff_text,
+                text=True,
+                capture_output=True,
+            )
+        except FileNotFoundError as exc:
+            print(f"Warning: git not available to apply diff: {exc}")
+            return set()
+
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or result.stdout.strip()
+            if error_msg:
+                print(f"git apply failed: {error_msg}")
+            else:
+                print("git apply failed without diagnostics.")
+            return set()
+
+        print("Applied diff from model output.")
+        return self._extract_paths_from_diff(diff_text)
+
+    def _extract_paths_from_diff(self, diff_text):
+        paths = set()
+        for line in diff_text.splitlines():
+            if line.startswith('diff --git'):
+                try:
+                    parts = shlex.split(line)
+                except ValueError:
+                    parts = line.split()
+                if len(parts) >= 4:
+                    for token in parts[2:4]:
+                        token = token.strip('"')
+                        if token.startswith('a/') or token.startswith('b/'):
+                            paths.add(token[2:])
+            elif line.startswith('+++ ') or line.startswith('--- '):
+                token = line[4:].strip()
+                if token == '/dev/null':
+                    continue
+                token = token.strip('"')
+                if token.startswith('a/') or token.startswith('b/'):
+                    token = token[2:]
+                paths.add(token)
+        cleaned = {p for p in paths if p and p != '/dev/null'}
+        return cleaned
+
+    def _apply_code_blocks(self, output):
+        pattern = re.compile(r"```(?P<header>[^\n]*)\n(?P<body>.*?)```", re.DOTALL)
+        updated_paths = set()
+
+        for match in pattern.finditer(output):
+            header = match.group('header').strip()
+            if header.lower() in {'diff', 'patch'}:
+                continue
+            body = match.group('body')
+            path, content = self._extract_file_update_from_block(header, body)
+            if not path:
+                continue
+            resolved_path = self._resolve_project_path(Path(path))
+            if not resolved_path:
+                print(f"Skipping invalid path in model output: {path}")
+                continue
+            resolved_path.parent.mkdir(parents=True, exist_ok=True)
+            if content and not content.endswith('\n'):
+                content += '\n'
+            try:
+                resolved_path.write_text(content, encoding='utf-8')
+            except OSError as exc:
+                print(f"Failed to write generated content to {resolved_path}: {exc}")
+                continue
+            relative = resolved_path.relative_to(self.project_root)
+            updated_paths.add(str(relative))
+            print(f"Updated {relative} from model output.")
+
+        return updated_paths
+
+    def _extract_file_update_from_block(self, header, body):
+        header = header.strip()
+        if self._header_looks_like_path(header):
+            return header, body
+
+        first_line, remainder = self._split_first_line(body)
+        possible_path = self._extract_path_marker(first_line)
+        if possible_path:
+            return possible_path, remainder
+
+        return None, body
+
+    def _header_looks_like_path(self, header):
+        if not header:
+            return False
+        lowered = header.lower()
+        language_tokens = {
+            'python', 'py', 'javascript', 'js', 'typescript', 'ts', 'tsx', 'jsx',
+            'json', 'yaml', 'yml', 'markdown', 'md', 'text', 'txt', 'bash', 'sh',
+            'shell', 'go', 'java', 'c', 'cpp', 'c++', 'rust', 'rb', 'ruby', 'php',
+            'html', 'css', 'sql', 'diff', 'patch', 'toml', 'ini', 'cfg'
+        }
+        if lowered in language_tokens or lowered.startswith('lang='):
+            return False
+        if '/' in header or '\\' in header:
+            return True
+        if '.' in header and ' ' not in header:
+            return True
+        return False
+
+    def _split_first_line(self, body):
+        if '\n' in body:
+            first, remainder = body.split('\n', 1)
+            return first, remainder
+        return body, ''
+
+    def _extract_path_marker(self, line):
+        cleaned = line.strip()
+        if not cleaned:
+            return None
+
+        prefixes = ('#', '//', '/*', '<!--')
+        for prefix in prefixes:
+            if cleaned.startswith(prefix):
+                cleaned = cleaned[len(prefix):].strip()
+                break
+
+        for suffix in ('-->', '*/'):
+            if cleaned.endswith(suffix):
+                cleaned = cleaned[:-len(suffix)].strip()
+
+        lower_cleaned = cleaned.lower()
+        if lower_cleaned.startswith('file:') or lower_cleaned.startswith('path:'):
+            return cleaned.split(':', 1)[1].strip()
+        return None
+
+    def _resolve_project_path(self, relative_path):
+        try:
+            if Path(relative_path).is_absolute():
+                candidate = Path(relative_path).resolve()
+            else:
+                candidate = (self.project_root / Path(relative_path)).resolve()
+            project_root = self.project_root.resolve()
+            candidate.relative_to(project_root)
+            return candidate
+        except (ValueError, OSError):
+            return None
+
+    def _stage_changes(self, paths):
+        if not paths:
+            print("No changes detected after applying model output.")
+            return
+
+        sorted_paths = sorted(paths)
+        try:
+            result = subprocess.run(
+                ['git', 'add', '--'] + sorted_paths,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            print(f"Warning: git not available to stage changes: {exc}")
+            return
+
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or result.stdout.strip()
+            if error_msg:
+                print(f"Warning: git add failed: {error_msg}")
+            else:
+                print("Warning: git add failed without diagnostics.")
+            return
+
+        print("Staged generated changes: " + ", ".join(sorted_paths))
+
+    def _get_pending_diff(self):
+        commands = [
+            ['git', 'diff', '--cached'],
+            ['git', 'diff'],
+        ]
+        collected_error = None
+
+        for command in commands:
+            try:
+                result = subprocess.run(
+                    command,
+                    cwd=self.project_root,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            except FileNotFoundError as exc:
+                collected_error = f"git not available for review diff: {exc}"
+                break
+
+            if result.returncode != 0:
+                error_msg = result.stderr.strip() or result.stdout.strip()
+                if error_msg:
+                    collected_error = error_msg
+                continue
+
+            diff_text = result.stdout.strip()
+            if diff_text:
+                return diff_text
+
+        if collected_error:
+            print(f"Warning: Unable to collect diff for review: {collected_error}")
+        return ""
+
+    def _record_review_feedback(self, feedback):
+        cleaned = feedback.strip()
+        if not cleaned:
+            print("Language model returned empty review feedback.")
+            return
+
+        separator = "=" * 60
+        print(separator)
+        print("Language model review feedback:")
+        print(cleaned)
+        print(separator)
+
+        review_path = self.project_root / 'douglas_review.md'
+        try:
+            review_path.parent.mkdir(parents=True, exist_ok=True)
+            new_file = not review_path.exists()
+            with review_path.open('a', encoding='utf-8') as fh:
+                if new_file:
+                    fh.write("# Douglas Review Feedback\n\n")
+                fh.write("## Latest Feedback\n\n")
+                fh.write(cleaned)
+                fh.write("\n\n")
+            print(f"Saved review feedback to {review_path.relative_to(self.project_root)}.")
+        except OSError as exc:
+            print(f"Warning: Unable to save review feedback to {review_path}: {exc}")
+
 
     def check(self):
         print("Checking Douglas configuration and environment...")

--- a/douglas/core.py
+++ b/douglas/core.py
@@ -67,7 +67,9 @@ class Douglas:
 
     def _resolve_sprint_length(self) -> Optional[int]:
         sprint_config = self.config.get('sprint', {}) or {}
-        raw_length = sprint_config.get('length_days', sprint_config.get('length'))
+        if 'length' in sprint_config:
+            print("Warning: 'length' is deprecated. Please use 'length_days' in the sprint configuration.")
+        raw_length = sprint_config.get('length_days')
         if raw_length is None:
             return None
         try:

--- a/douglas/integrations/github.py
+++ b/douglas/integrations/github.py
@@ -1,17 +1,34 @@
 import subprocess
 
+
 class GitHub:
     @staticmethod
-    def create_pull_request(title: str, body: str, base: str='main', head: str=None):
+    def create_pull_request(title: str, body: str, base: str = 'main', head: str = None):
         if not head:
-            head = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], text=True).strip()
+            head = subprocess.check_output(
+                ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], text=True
+            ).strip()
+
+        command = [
+            'gh',
+            'pr',
+            'create',
+            '--title',
+            title,
+            '--body',
+            body,
+            '--base',
+            base,
+            '--head',
+            head,
+        ]
+
         try:
-            subprocess.run([
-                'gh', 'pr', 'create',
-                '--title', title,
-                '--body', body,
-                '--base', base,
-                '--head', head
-            ], check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Failed to create PR: {e}")
+            result = subprocess.run(
+                command, check=True, capture_output=True, text=True
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f'Failed to create PR: {exc.stderr or exc.stdout}') from exc
+
+        output = result.stdout.strip() or result.stderr.strip()
+        return output or f'Pull request created for {head} -> {base}'

--- a/douglas/pipelines/lint.py
+++ b/douglas/pipelines/lint.py
@@ -23,7 +23,7 @@ def run_lint(additional_commands: Optional[Iterable[Sequence[str]]] = None) -> N
     commands: list[Sequence[str]] = [
         ['ruff', '.'],
         ['black', '--check', '.'],
-        ['isort', '--check-only', '.'],
+        ['isort', '--check', '.'],
     ]
 
     if additional_commands:

--- a/douglas/pipelines/lint.py
+++ b/douglas/pipelines/lint.py
@@ -1,12 +1,35 @@
 import subprocess
-import sys
+from typing import Iterable, Optional, Sequence
 
-def run_lint():
+
+def _run_command(command: Sequence[str]) -> None:
+    """Run a single linter command, exiting with an error on failure."""
+
     try:
-        subprocess.run(['ruff', '.'], check=True)
-        subprocess.run(['black', '--check', '.'], check=True)
-        subprocess.run(['isort', '--check', '.'], check=True)
-        print("Lint checks passed.")
-    except subprocess.CalledProcessError:
-        print("Lint checks failed.")
-        sys.exit(1)
+        subprocess.run(command, check=True)
+    except FileNotFoundError:
+        print(f"Required linter '{command[0]}' is not installed or not on PATH.")
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        cmd_display = " ".join(command)
+        exit_code = exc.returncode or 1
+        print(f"Lint command '{cmd_display}' failed with exit code {exit_code}.")
+        raise SystemExit(exit_code)
+
+
+def run_lint(additional_commands: Optional[Iterable[Sequence[str]]] = None) -> None:
+    """Execute lint commands and exit with a non-zero code when they fail."""
+
+    commands: list[Sequence[str]] = [
+        ['ruff', '.'],
+        ['black', '--check', '.'],
+        ['isort', '--check-only', '.'],
+    ]
+
+    if additional_commands:
+        commands.extend(additional_commands)
+
+    for command in commands:
+        _run_command(command)
+
+    print("Lint checks passed.")

--- a/douglas/pipelines/typecheck.py
+++ b/douglas/pipelines/typecheck.py
@@ -1,10 +1,39 @@
 import subprocess
-import sys
+from typing import Iterable, Optional, Sequence
 
-def run_typecheck():
+
+def _run_command(command: Sequence[str]) -> None:
+    """Run a single type-check command, exiting with an error on failure."""
+
     try:
-        subprocess.run(['mypy', '.'], check=True)
-        print("Type check passed.")
-    except subprocess.CalledProcessError:
-        print("Type check failed.")
-        sys.exit(1)
+        subprocess.run(command, check=True)
+    except FileNotFoundError:
+        print(
+            f"Required type checker '{command[0]}' is not installed or not on PATH."
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        cmd_display = " ".join(command)
+        exit_code = exc.returncode or 1
+        print(
+            f"Type-check command '{cmd_display}' failed with exit code {exit_code}."
+        )
+        raise SystemExit(exit_code)
+
+
+def run_typecheck(
+    additional_commands: Optional[Iterable[Sequence[str]]] = None,
+) -> None:
+    """Execute type-check commands and exit with a non-zero code when they fail."""
+
+    commands: list[Sequence[str]] = [
+        ['mypy', '.'],
+    ]
+
+    if additional_commands:
+        commands.extend(additional_commands)
+
+    for command in commands:
+        _run_command(command)
+
+    print("Type checks passed.")

--- a/douglas/sprint_manager.py
+++ b/douglas/sprint_manager.py
@@ -1,0 +1,343 @@
+"""Utility helpers for tracking sprint cadence and release policies."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class CadenceDecision:
+    """Represents the decision for whether a step should execute."""
+
+    should_run: bool
+    reason: str
+    event_type: Optional[str] = None
+
+
+def _normalize_cadence(cadence: Optional[object]) -> Optional[str]:
+    """Extract the frequency token from a cadence configuration value."""
+
+    if cadence is None:
+        return None
+    if isinstance(cadence, str):
+        return cadence.strip() or None
+    if isinstance(cadence, dict):
+        for key in ("frequency", "cadence", "type"):
+            value = cadence.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def should_run_step(
+    step_name: str,
+    sprint_day: int,
+    sprint_length: int,
+    cadence: Optional[object],
+    *,
+    available_events: Optional[Dict[str, int]] = None,
+    run_count: int = 0,
+    per_sprint_consumed: int = 0,
+) -> CadenceDecision:
+    """Determine whether a step should run under the provided cadence rules."""
+
+    frequency = _normalize_cadence(cadence)
+    if not frequency:
+        return CadenceDecision(True, "Cadence defaults to daily execution.")
+
+    frequency = frequency.lower()
+    available_events = available_events or {}
+    sprint_day = max(sprint_day, 1)
+    sprint_length = max(sprint_length, 0)
+
+    if frequency in {"daily", "every_day", "each_iteration"}:
+        return CadenceDecision(True, "Daily cadence executes every iteration.")
+
+    if frequency == "once":
+        if run_count == 0:
+            return CadenceDecision(True, "Once cadence has not yet executed this sprint.")
+        return CadenceDecision(False, "Once cadence already satisfied for this sprint.")
+
+    if frequency == "per_sprint":
+        if sprint_length <= 0:
+            return CadenceDecision(True, "Sprint length unspecified; executing per-sprint step.", "sprint")
+        if sprint_day == sprint_length and per_sprint_consumed == 0:
+            return CadenceDecision(
+                True,
+                f"Final sprint day reached ({sprint_day}/{sprint_length}).",
+                "sprint",
+            )
+        if sprint_day != sprint_length:
+            return CadenceDecision(
+                False,
+                f"Per-sprint cadence waits for day {sprint_length}; currently day {sprint_day}.",
+            )
+        return CadenceDecision(False, "Per-sprint cadence already completed for this sprint.")
+
+    event_frequency_map = {
+        "per_feature": "feature",
+        "per_bug": "bug",
+        "per_epic": "epic",
+    }
+
+    if frequency in event_frequency_map:
+        event_key = event_frequency_map[frequency]
+        pending = max(available_events.get(event_key, 0), 0)
+        if pending > 0:
+            plural = "s" if pending != 1 else ""
+            return CadenceDecision(
+                True,
+                f"{pending} {event_key}{plural} awaiting follow-up.",
+                event_key,
+            )
+        return CadenceDecision(False, f"No pending {event_key} work queued for this cadence.")
+
+    return CadenceDecision(True, f"Unrecognized cadence '{frequency}'; defaulting to execution.")
+
+
+class SprintManager:
+    """Tracks sprint progress and cadence-driven events."""
+
+    _COMMIT_PATTERN = re.compile(r"^(?P<type>[a-zA-Z]+)(?P<breaking>!)?(?:\((?P<scope>[^)]+)\))?:")
+
+    def __init__(self, sprint_length_days: Optional[int] = None) -> None:
+        if sprint_length_days is None:
+            sprint_length_days = 10
+        if sprint_length_days <= 0:
+            sprint_length_days = 1
+
+        self.sprint_length_days = sprint_length_days
+        self.current_day = 1
+        self.current_iteration = 1
+        self.sprint_index = 1
+
+        self.pending_events: Dict[str, int] = {"feature": 0, "bug": 0, "epic": 0}
+        self.event_consumption: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        self.step_run_counts: Dict[str, int] = defaultdict(int)
+
+        self.completed_features: set[str] = set()
+        self.completed_bugs: set[str] = set()
+        self.completed_epics: set[str] = set()
+
+        self.push_executed_this_sprint = False
+        self.pr_executed_this_sprint = False
+
+        self.commits_since_last_push = 0
+        self.commits_since_last_pr = 0
+
+    # ------------------------------------------------------------------
+    # Sprint progression
+    # ------------------------------------------------------------------
+    def is_final_day(self) -> bool:
+        return self.current_day >= self.sprint_length_days
+
+    def finish_iteration(self) -> None:
+        self.current_iteration += 1
+        self.current_day += 1
+        if self.current_day > self.sprint_length_days:
+            self.start_new_sprint()
+
+    def start_new_sprint(self) -> None:
+        self.sprint_index += 1
+        self.current_day = 1
+        self.current_iteration = 1
+
+        self.pending_events = {"feature": 0, "bug": 0, "epic": 0}
+        self.event_consumption = defaultdict(lambda: defaultdict(int))
+        self.step_run_counts = defaultdict(int)
+
+        self.completed_features.clear()
+        self.completed_bugs.clear()
+        self.completed_epics.clear()
+
+        self.push_executed_this_sprint = False
+        self.pr_executed_this_sprint = False
+        self.commits_since_last_push = 0
+        self.commits_since_last_pr = 0
+
+    # ------------------------------------------------------------------
+    # Cadence evaluation
+    # ------------------------------------------------------------------
+    def should_run_step(self, step_name: str, cadence: Optional[object]) -> CadenceDecision:
+        available = {
+            "feature": self._available_event_for_consumer("feature", step_name),
+            "bug": self._available_event_for_consumer("bug", step_name),
+            "epic": self._available_event_for_consumer("epic", step_name),
+        }
+        per_sprint_consumed = self.event_consumption[step_name]["sprint"]
+        run_count = self.step_run_counts[step_name]
+        return should_run_step(
+            step_name,
+            self.current_day,
+            self.sprint_length_days,
+            cadence,
+            available_events=available,
+            run_count=run_count,
+            per_sprint_consumed=per_sprint_consumed,
+        )
+
+    def record_step_execution(self, step_name: str, event_type: Optional[str]) -> None:
+        self.step_run_counts[step_name] += 1
+        if event_type:
+            self.event_consumption[step_name][event_type] += 1
+
+    def has_step_run(self, step_name: str) -> bool:
+        return self.step_run_counts.get(step_name, 0) > 0
+
+    # ------------------------------------------------------------------
+    # Event and commit tracking
+    # ------------------------------------------------------------------
+    def mark_feature_completed(self, identifier: Optional[str] = None) -> None:
+        self.pending_events["feature"] += 1
+        if identifier:
+            self.completed_features.add(str(identifier))
+
+    def mark_bug_completed(self, identifier: Optional[str] = None) -> None:
+        self.pending_events["bug"] += 1
+        if identifier:
+            self.completed_bugs.add(str(identifier))
+
+    def mark_epic_completed(self, identifier: Optional[str] = None) -> None:
+        self.pending_events["epic"] += 1
+        if identifier:
+            self.completed_epics.add(str(identifier))
+
+    def record_commit(self, message: Optional[str]) -> None:
+        if not message:
+            return
+
+        self.commits_since_last_push += 1
+        self.commits_since_last_pr += 1
+
+        match = self._COMMIT_PATTERN.match(message.strip())
+        if not match:
+            return
+
+        commit_type = (match.group("type") or "").lower()
+        scope = (match.group("scope") or "").strip()
+
+        if commit_type == "feat":
+            self.mark_feature_completed(scope or None)
+        elif commit_type == "fix":
+            self.mark_bug_completed(scope or None)
+        elif commit_type == "epic":
+            self.mark_epic_completed(scope or None)
+        else:
+            if scope and "epic" in scope.lower():
+                self.mark_epic_completed(scope)
+
+    # ------------------------------------------------------------------
+    # Push / PR policy coordination
+    # ------------------------------------------------------------------
+    def should_run_push(self, push_policy: str) -> CadenceDecision:
+        policy = (push_policy or "per_feature").lower()
+
+        if policy == "per_feature":
+            available = self._available_event_for_consumer("feature", "push")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} feature{plural} ready to push.", "feature")
+            return CadenceDecision(False, "Push policy per_feature: no completed features pending.")
+
+        if policy == "per_bug":
+            available = self._available_event_for_consumer("bug", "push")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} bug fix{plural} ready to push.", "bug")
+            return CadenceDecision(False, "Push policy per_bug: no resolved bugs pending push.")
+
+        if policy == "per_epic":
+            available = self._available_event_for_consumer("epic", "push")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} epic{plural} ready for integration.", "epic")
+            return CadenceDecision(False, "Push policy per_epic: no completed epics pending push.")
+
+        if policy == "per_sprint":
+            if not self.is_final_day():
+                return CadenceDecision(
+                    False,
+                    f"Push policy per_sprint waits for day {self.sprint_length_days}; current day {self.current_day}.",
+                )
+            if self.push_executed_this_sprint:
+                return CadenceDecision(False, "Push already executed for this sprint.")
+            if self.commits_since_last_push <= 0:
+                return CadenceDecision(False, "No new commits accumulated for sprint push.")
+            return CadenceDecision(True, "Final sprint day; pushing accumulated commits.", "sprint")
+
+        return CadenceDecision(True, f"Unknown push policy '{policy}'; defaulting to push.")
+
+    def record_push(self, event_type: Optional[str], push_policy: str) -> None:
+        self.record_step_execution("push", event_type)
+        policy = (push_policy or "per_feature").lower()
+
+        if policy == "per_sprint":
+            self.push_executed_this_sprint = True
+            self.commits_since_last_push = 0
+        else:
+            if self.commits_since_last_push > 0:
+                self.commits_since_last_push = max(0, self.commits_since_last_push - 1)
+
+    def should_open_pr(self, push_policy: str) -> CadenceDecision:
+        policy = (push_policy or "per_feature").lower()
+
+        if policy == "per_feature":
+            available = self._available_event_for_consumer("feature", "pr")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} feature{plural} ready for PR.", "feature")
+            return CadenceDecision(False, "PR policy per_feature: no completed features pending.")
+
+        if policy == "per_bug":
+            available = self._available_event_for_consumer("bug", "pr")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} bug fix{plural} ready for PR.", "bug")
+            return CadenceDecision(False, "PR policy per_bug: no resolved bugs pending PR.")
+
+        if policy == "per_epic":
+            available = self._available_event_for_consumer("epic", "pr")
+            if available > 0:
+                plural = "s" if available != 1 else ""
+                return CadenceDecision(True, f"{available} epic{plural} ready for showcase.", "epic")
+            return CadenceDecision(False, "PR policy per_epic: no completed epics pending PR.")
+
+        if policy == "per_sprint":
+            if not self.is_final_day():
+                return CadenceDecision(
+                    False,
+                    f"PR policy per_sprint waits for day {self.sprint_length_days}; current day {self.current_day}.",
+                )
+            if self.pr_executed_this_sprint:
+                return CadenceDecision(False, "PR already created for this sprint.")
+            if self.commits_since_last_pr <= 0:
+                return CadenceDecision(False, "No new commits accumulated for sprint PR.")
+            return CadenceDecision(True, "Final sprint day; preparing sprint PR.", "sprint")
+
+        return CadenceDecision(True, f"Unknown PR policy '{policy}'; defaulting to create PR.")
+
+    def record_pr(self, event_type: Optional[str], push_policy: str) -> None:
+        self.record_step_execution("pr", event_type)
+        policy = (push_policy or "per_feature").lower()
+
+        if policy == "per_sprint":
+            self.pr_executed_this_sprint = True
+            self.commits_since_last_pr = 0
+        else:
+            if self.commits_since_last_pr > 0:
+                self.commits_since_last_pr = max(0, self.commits_since_last_pr - 1)
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _available_event_for_consumer(self, event_type: str, consumer: str) -> int:
+        pending = self.pending_events.get(event_type, 0)
+        consumed = self.event_consumption[consumer][event_type]
+        remaining = pending - consumed
+        return remaining if remaining > 0 else 0
+
+    def describe_day(self) -> str:
+        return f"day {self.current_day} of sprint {self.sprint_index}"

--- a/douglas/sprint_manager.py
+++ b/douglas/sprint_manager.py
@@ -61,6 +61,9 @@ def should_run_step(
             return CadenceDecision(True, "Once cadence has not yet executed this sprint.")
         return CadenceDecision(False, "Once cadence already satisfied for this sprint.")
 
+    if frequency in {"on_demand", "on-demand"}:
+        return CadenceDecision(False, "On-demand cadence requires manual trigger.")
+
     if frequency == "per_sprint":
         if sprint_length <= 0:
             return CadenceDecision(True, "Sprint length unspecified; executing per-sprint step.", "sprint")

--- a/templates/douglas.yaml.tpl
+++ b/templates/douglas.yaml.tpl
@@ -7,5 +7,44 @@ ai:
   provider: "openai"
   model: "gpt-4"
   prompt: "system_prompt.md"
+cadence:
+  Developer:
+    development: daily
+    quality_checks: daily
+    code_review: per_feature
+  Tester:
+    test_cases: daily
+  ProductOwner:
+    backlog_refinement: per_sprint
+    sprint_review: per_sprint
+  ScrumMaster:
+    daily_standup: daily
+    retrospective: per_sprint
+  DevOps:
+    release: per_feature
 loop:
-  steps: ["lint", "typecheck", "test"]
+  steps:
+    - name: generate
+      role: Developer
+      activity: development
+    - name: lint
+      role: Developer
+      activity: quality_checks
+    - name: typecheck
+      role: Developer
+      activity: quality_checks
+    - name: test
+      role: Tester
+      activity: test_cases
+    - name: review
+      role: Developer
+      activity: code_review
+    - name: commit
+      role: Developer
+      activity: development
+    - name: push
+      role: DevOps
+      activity: release
+    - name: pr
+      role: Developer
+      activity: code_review

--- a/tests/test_cadence_manager.py
+++ b/tests/test_cadence_manager.py
@@ -1,0 +1,108 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.cadence_manager import CadenceManager, should_run_step
+from douglas.sprint_manager import SprintManager
+
+
+def _build_manager(config, sprint_length=4):
+    sprint = SprintManager(sprint_length_days=sprint_length)
+    cadence = CadenceManager(config, sprint)
+    return sprint, cadence
+
+
+def test_daily_developer_cadence_runs_each_iteration():
+    config = {'Developer': {'development': 'daily'}}
+    sprint, cadence = _build_manager(config, sprint_length=2)
+
+    decision_day_one = cadence.evaluate_step(
+        'generate', {'name': 'generate', 'role': 'Developer', 'activity': 'development'}
+    )
+    assert decision_day_one.should_run is True
+
+    sprint.record_step_execution('generate', decision_day_one.event_type)
+    sprint.finish_iteration()
+
+    decision_day_two = cadence.evaluate_step(
+        'generate', {'name': 'generate', 'role': 'Developer', 'activity': 'development'}
+    )
+    assert decision_day_two.should_run is True
+
+
+def test_per_sprint_retrospective_waits_for_final_day():
+    config = {'ScrumMaster': {'retrospective': 'per_sprint'}}
+    sprint, cadence = _build_manager(config, sprint_length=3)
+
+    early = cadence.evaluate_step(
+        'retrospective',
+        {'name': 'retrospective', 'role': 'ScrumMaster', 'activity': 'retrospective'},
+    )
+    assert early.should_run is False
+    assert 'defers execution' in early.reason
+
+    sprint.current_day = sprint.sprint_length_days
+    final = cadence.evaluate_step(
+        'retrospective',
+        {'name': 'retrospective', 'role': 'ScrumMaster', 'activity': 'retrospective'},
+    )
+    assert final.should_run is True
+    sprint.record_step_execution('retrospective', final.event_type)
+
+    follow_up = cadence.evaluate_step(
+        'retrospective',
+        {'name': 'retrospective', 'role': 'ScrumMaster', 'activity': 'retrospective'},
+    )
+    assert follow_up.should_run is False
+
+
+def test_per_feature_review_runs_when_feature_available():
+    config = {'Developer': {'code_review': 'per_feature'}}
+    sprint, cadence = _build_manager(config, sprint_length=5)
+
+    first = cadence.evaluate_step(
+        'review', {'name': 'review', 'role': 'Developer', 'activity': 'code_review'}
+    )
+    assert first.should_run is False
+
+    sprint.record_commit('feat: initial capability')
+    pending = cadence.evaluate_step(
+        'review', {'name': 'review', 'role': 'Developer', 'activity': 'code_review'}
+    )
+    assert pending.should_run is True
+    sprint.record_step_execution('review', pending.event_type)
+
+    follow_up = cadence.evaluate_step(
+        'review', {'name': 'review', 'role': 'Developer', 'activity': 'code_review'}
+    )
+    assert follow_up.should_run is False
+
+
+def test_on_demand_cadence_skips_until_triggered():
+    config = {'Stakeholder': {'check_in': 'on_demand'}}
+    sprint, cadence = _build_manager(config)
+
+    decision = cadence.evaluate_step(
+        'status_update',
+        {'name': 'status_update', 'role': 'Stakeholder', 'activity': 'check_in'},
+    )
+    assert decision.should_run is False
+    assert 'on-demand' in decision.reason.lower()
+
+
+def test_should_run_step_helper_exposes_context():
+    config = {'Developer': {'development': 'daily'}}
+    sprint, cadence = _build_manager(config)
+
+    decision = cadence.evaluate_step(
+        'generate', {'name': 'generate', 'role': 'Developer', 'activity': 'development'}
+    )
+    assert decision.should_run is True
+    context = cadence.last_context
+    assert context is not None
+    assert context.sprint_day == 1
+    assert context.available_events['feature'] == 0
+
+    assert should_run_step(context.role, context.activity, context) is True
+    assert context.decision is not None

--- a/tests/test_ci_monitoring.py
+++ b/tests/test_ci_monitoring.py
@@ -1,0 +1,143 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+def _init_repo(tmp_path: Path, *, steps: List[dict], exit_conditions: Optional[List[str]] = None) -> Path:
+    subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ['git', 'config', 'user.email', 'test@example.com'],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ['git', 'config', 'user.name', 'Test User'],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    config_data: dict = {
+        'project': {'name': 'CITracking', 'language': 'python'},
+        'ai': {'provider': 'openai'},
+        'loop': {'steps': steps},
+        'push_policy': 'per_feature',
+    }
+    if exit_conditions is not None:
+        config_data['loop']['exit_conditions'] = exit_conditions
+
+    config_path = tmp_path / 'douglas.yaml'
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding='utf-8')
+
+    (tmp_path / 'README.md').write_text('Initial content\n', encoding='utf-8')
+
+    subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'chore: initial'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    return config_path
+
+
+def _force_gh_available(monkeypatch):
+    original = shutil.which
+
+    def fake_which(command: str):
+        if command == 'gh':
+            return '/usr/bin/gh'
+        return original(command)
+
+    monkeypatch.setattr(shutil, 'which', fake_which)
+
+
+def test_monitor_ci_records_failure(monkeypatch, tmp_path):
+    config_path = _init_repo(tmp_path, steps=[{'name': 'commit'}], exit_conditions=[])
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: object())
+    douglas = Douglas(config_path)
+
+    commit_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=tmp_path, text=True).strip()
+    gh_runs = json.dumps([
+        {
+            'databaseId': 42,
+            'headSha': commit_sha,
+            'status': 'completed',
+            'conclusion': 'failure',
+            'url': 'https://ci.example.test/run',
+        }
+    ])
+
+    original_run = subprocess.run
+
+    def fake_run(command, *args, **kwargs):
+        if command[:3] == ['gh', 'run', 'list']:
+            return subprocess.CompletedProcess(command, 0, stdout=gh_runs, stderr='')
+        if command[:3] == ['gh', 'run', 'view']:
+            return subprocess.CompletedProcess(command, 0, stdout='CI failure log\n', stderr='')
+        return original_run(command, *args, **kwargs)
+
+    _force_gh_available(monkeypatch)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    result = douglas._monitor_ci(max_attempts=1, poll_interval=0)
+    assert result is False
+    assert douglas._ci_status == 'failure'
+
+    bug_file = tmp_path / 'ai-inbox' / 'bugs.md'
+    assert bug_file.exists()
+    bug_contents = bug_file.read_text(encoding='utf-8')
+    assert 'CI run 42 failed with conclusion failure.' in bug_contents
+    assert 'CI failure log' in bug_contents
+
+    history_path = tmp_path / 'ai-inbox' / 'history.jsonl'
+    history_entries = [json.loads(line) for line in history_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    events = [entry['event'] for entry in history_entries]
+    assert 'ci_fail' in events
+    assert 'bug_reported' in events
+
+
+def test_monitor_ci_records_success(monkeypatch, tmp_path):
+    config_path = _init_repo(tmp_path, steps=[{'name': 'commit'}], exit_conditions=[])
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: object())
+    douglas = Douglas(config_path)
+
+    commit_sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=tmp_path, text=True).strip()
+    gh_runs = json.dumps([
+        {
+            'databaseId': 101,
+            'headSha': commit_sha,
+            'status': 'completed',
+            'conclusion': 'success',
+            'url': 'https://ci.example.test/run/101',
+        }
+    ])
+
+    original_run = subprocess.run
+
+    def fake_run(command, *args, **kwargs):
+        if command[:3] == ['gh', 'run', 'list']:
+            return subprocess.CompletedProcess(command, 0, stdout=gh_runs, stderr='')
+        if command[:3] == ['gh', 'run', 'view']:
+            raise AssertionError('gh run view should not be called when CI succeeds')
+        return original_run(command, *args, **kwargs)
+
+    _force_gh_available(monkeypatch)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    result = douglas._monitor_ci(max_attempts=1, poll_interval=0)
+    assert result is True
+    assert douglas._ci_status == 'success'
+
+    history_path = tmp_path / 'ai-inbox' / 'history.jsonl'
+    history_entries = [json.loads(line) for line in history_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    assert any(entry['event'] == 'ci_pass' for entry in history_entries)
+    assert not (tmp_path / 'ai-inbox' / 'bugs.md').exists()

--- a/tests/test_commit_step.py
+++ b/tests/test_commit_step.py
@@ -1,0 +1,119 @@
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+class RecordingProvider:
+    def __init__(self, response):
+        self.response = response
+        self.prompts: list[str] = []
+        self.called = False
+
+    def generate_code(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        self.called = True
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+class FailingProvider(RecordingProvider):
+    def __init__(self):
+        super().__init__(RuntimeError("llm failure"))
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    config_content = textwrap.dedent(
+        """
+        project:
+          name: 'CommitTest'
+          language: 'python'
+        ai:
+          provider: 'openai'
+        loop:
+          steps: []
+        """
+    )
+    (tmp_path / 'douglas.yaml').write_text(config_content, encoding='utf-8')
+    (tmp_path / 'README.md').write_text("Initial content\n", encoding='utf-8')
+
+    subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'chore: initial'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    return tmp_path / 'douglas.yaml'
+
+
+def _git_output(path: Path, *args: str) -> str:
+    result = subprocess.run(['git', *args], cwd=path, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def test_commit_step_creates_commit_with_llm_message(monkeypatch, tmp_path):
+    config_path = _init_git_repo(tmp_path)
+    provider = RecordingProvider("feat: update readme.\n\n- add more details")
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    douglas = Douglas(config_path)
+    initial_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+
+    readme = tmp_path / 'README.md'
+    readme.write_text("Initial content\nMore docs\n", encoding='utf-8')
+
+    douglas.run_loop()
+
+    new_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+    assert new_head != initial_head
+
+    commit_message = _git_output(tmp_path, 'log', '-1', '--pretty=%B')
+    assert commit_message == 'feat: update readme'
+    assert provider.called
+    assert provider.prompts
+    assert 'STAGED DIFF' in provider.prompts[0]
+
+    status = _git_output(tmp_path, 'status', '--porcelain')
+    assert status == ''
+
+
+def test_commit_step_falls_back_when_llm_fails(monkeypatch, tmp_path):
+    config_path = _init_git_repo(tmp_path)
+    provider = FailingProvider()
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    douglas = Douglas(config_path)
+    initial_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+
+    target = tmp_path / 'README.md'
+    target.write_text("Initial content\nAnother line\n", encoding='utf-8')
+
+    douglas.run_loop()
+
+    new_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+    assert new_head != initial_head
+
+    commit_message = _git_output(tmp_path, 'log', '-1', '--pretty=%B')
+    assert commit_message == Douglas.DEFAULT_COMMIT_MESSAGE
+    assert provider.called
+
+
+def test_commit_step_skips_when_no_changes(monkeypatch, tmp_path):
+    config_path = _init_git_repo(tmp_path)
+    provider = RecordingProvider('feat: unused message')
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    douglas = Douglas(config_path)
+    initial_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+
+    douglas.run_loop()
+
+    final_head = _git_output(tmp_path, 'rev-parse', 'HEAD')
+    assert final_head == initial_head
+    assert not provider.called

--- a/tests/test_history_logging.py
+++ b/tests/test_history_logging.py
@@ -1,0 +1,54 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    config = {
+        'project': {'name': 'History', 'language': 'python'},
+        'ai': {'provider': 'openai'},
+        'loop': {'steps': [{'name': 'commit'}]},
+    }
+    config_path = tmp_path / 'douglas.yaml'
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding='utf-8')
+
+    (tmp_path / 'README.md').write_text('Initial content\n', encoding='utf-8')
+
+    subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'chore: initial'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    return config_path
+
+
+def test_commit_adds_history_entry(monkeypatch, tmp_path):
+    config_path = _init_repo(tmp_path)
+
+    class Provider:
+        def generate_code(self, prompt: str) -> str:
+            return 'feat: update docs'
+
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: Provider())
+
+    douglas = Douglas(config_path)
+    readme = tmp_path / 'README.md'
+    readme.write_text('Initial content\nMore docs\n', encoding='utf-8')
+
+    douglas.run_loop()
+
+    history_path = tmp_path / 'ai-inbox' / 'history.jsonl'
+    assert history_path.exists()
+    entries = [json.loads(line) for line in history_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    commit_events = [entry for entry in entries if entry['event'] == 'commit']
+    assert commit_events, 'Expected at least one commit event in history.'
+    assert commit_events[-1]['message'] == 'feat: update docs'

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+def test_init_project_creates_scaffold(monkeypatch, tmp_path):
+    base_config = tmp_path / 'douglas.yaml'
+    base_config.write_text('project:\n  name: Base\n', encoding='utf-8')
+
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: object())
+
+    douglas = Douglas(base_config)
+    target_dir = tmp_path / 'scaffold'
+
+    douglas.init_project(str(target_dir))
+
+    expected_paths = [
+        target_dir / 'douglas.yaml',
+        target_dir / 'README.md',
+        target_dir / 'system_prompt.md',
+        target_dir / '.gitignore',
+        target_dir / 'src' / '__init__.py',
+        target_dir / 'src' / 'main.py',
+        target_dir / 'tests' / 'test_main.py',
+        target_dir / '.github' / 'workflows' / 'ci.yml',
+    ]
+
+    for path in expected_paths:
+        assert path.exists(), f'Missing expected scaffold file: {path}'
+
+    ci_content = (target_dir / '.github' / 'workflows' / 'ci.yml').read_text(encoding='utf-8')
+    assert 'name: CI' in ci_content
+    assert 'pytest' in ci_content
+
+    readme_text = (target_dir / 'README.md').read_text(encoding='utf-8')
+    assert target_dir.name in readme_text
+    assert 'Douglas' in readme_text

--- a/tests/test_lint_pipeline.py
+++ b/tests/test_lint_pipeline.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.pipelines import lint
+
+
+def _completed(command: list[str]):
+    return subprocess.CompletedProcess(command, 0)
+
+
+def test_run_lint_executes_all_commands(monkeypatch):
+    calls = []
+
+    def fake_run(command, check=True):
+        calls.append((tuple(command), check))
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    lint.run_lint(additional_commands=[['echo', 'ok']])
+
+    expected_commands = [
+        ('ruff', '.'),
+        ('black', '--check', '.'),
+        ('isort', '--check-only', '.'),
+        ('echo', 'ok'),
+    ]
+    assert [call[0] for call in calls] == expected_commands
+    assert all(check is True for _, check in calls)
+
+
+def test_run_lint_fails_on_linter_error(monkeypatch):
+    def fake_run(command, check=True):
+        if command[0] == 'black':
+            raise subprocess.CalledProcessError(returncode=3, cmd=command)
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        lint.run_lint()
+
+    assert exc_info.value.code == 3
+
+
+def test_run_lint_handles_missing_command(monkeypatch):
+    def fake_run(command, check=True):
+        if command[0] == 'ruff':
+            raise FileNotFoundError('ruff not found')
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        lint.run_lint()
+
+    assert exc_info.value.code == 1

--- a/tests/test_local_checks.py
+++ b/tests/test_local_checks.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+class StaticProvider:
+    def generate_code(self, prompt: str) -> str:
+        return 'chore: update'
+
+
+def _init_repo(tmp_path: Path, *, steps: List[dict], exit_conditions: Optional[List[str]] = None) -> Path:
+    subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ['git', 'config', 'user.email', 'test@example.com'],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ['git', 'config', 'user.name', 'Test User'],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    config_data: dict = {
+        'project': {'name': 'LocalChecks', 'language': 'python'},
+        'ai': {'provider': 'openai'},
+        'loop': {'steps': steps},
+        'push_policy': 'per_feature',
+    }
+    if exit_conditions is not None:
+        config_data['loop']['exit_conditions'] = exit_conditions
+
+    config_path = tmp_path / 'douglas.yaml'
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding='utf-8')
+
+    readme = tmp_path / 'README.md'
+    readme.write_text('Initial content\n', encoding='utf-8')
+
+    subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'chore: initial'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    return config_path
+
+
+def test_push_step_creates_bug_on_local_check_failure(monkeypatch, tmp_path):
+    config_path = _init_repo(tmp_path, steps=[{'name': 'push'}], exit_conditions=[])
+
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: StaticProvider())
+
+    douglas = Douglas(config_path)
+    douglas.sprint_manager.mark_feature_completed('demo-feature')
+    douglas.sprint_manager.commits_since_last_push = 1
+
+    local_logs = 'simulated local check failure'
+
+    def fake_local_checks(self):
+        return False, local_logs
+
+    def unexpected_push(self):
+        raise AssertionError('push should not run when local checks fail')
+
+    monkeypatch.setattr(Douglas, '_run_local_checks', fake_local_checks)
+    monkeypatch.setattr(Douglas, '_run_git_push', unexpected_push)
+    monkeypatch.setattr(Douglas, '_monitor_ci', lambda self: None)
+
+    douglas.run_loop()
+
+    bug_file = tmp_path / 'ai-inbox' / 'bugs.md'
+    assert bug_file.exists()
+    bug_contents = bug_file.read_text(encoding='utf-8')
+    assert 'simulated local check failure' in bug_contents
+
+    history_path = tmp_path / 'ai-inbox' / 'history.jsonl'
+    assert history_path.exists()
+    events = [json.loads(line)['event'] for line in history_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    assert 'bug_reported' in events
+    assert 'step_failure' in events
+
+
+def test_run_local_checks_success_records_history(monkeypatch, tmp_path):
+    config_path = _init_repo(tmp_path, steps=[{'name': 'push'}], exit_conditions=[])
+
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: StaticProvider())
+    douglas = Douglas(config_path)
+
+    monkeypatch.setattr(Douglas, '_discover_local_check_commands', lambda self: [['echo', 'ok']])
+
+    original_run = subprocess.run
+
+    def fake_run(command, *args, **kwargs):
+        if command == ['echo', 'ok']:
+            return subprocess.CompletedProcess(command, 0, stdout='all good\n', stderr='')
+        return original_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    success, logs = douglas._run_local_checks()
+    assert success is True
+    assert 'all good' in logs
+
+    history_path = tmp_path / 'ai-inbox' / 'history.jsonl'
+    assert history_path.exists()
+    entries = [json.loads(line) for line in history_path.read_text(encoding='utf-8').splitlines() if line.strip()]
+    assert any(entry['event'] == 'local_checks_pass' for entry in entries)

--- a/tests/test_push_policy.py
+++ b/tests/test_push_policy.py
@@ -1,0 +1,116 @@
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+from douglas.core import Douglas
+
+
+class SequencedProvider:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.prompts: list[str] = []
+
+    def generate_code(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if self._responses:
+            return self._responses.pop(0)
+        return 'chore: automated commit'
+
+
+def _init_repo(
+    tmp_path: Path,
+    *,
+    push_policy: str,
+    sprint_length: Optional[int],
+    steps: List[dict],
+) -> Path:
+    subprocess.run(['git', 'init'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    config_data: dict = {
+        'project': {'name': 'PushPolicy', 'language': 'python'},
+        'ai': {'provider': 'openai'},
+        'loop': {'steps': steps},
+        'push_policy': push_policy,
+    }
+    if sprint_length is not None:
+        config_data['sprint'] = {'length_days': sprint_length}
+
+    config_path = tmp_path / 'douglas.yaml'
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding='utf-8')
+
+    readme = tmp_path / 'README.md'
+    readme.write_text('Initial content\n', encoding='utf-8')
+
+    subprocess.run(['git', 'add', '.'], cwd=tmp_path, check=True, capture_output=True, text=True)
+    subprocess.run(['git', 'commit', '-m', 'chore: initial'], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    return config_path
+
+
+def test_per_feature_policy_pushes_and_creates_pr(monkeypatch, tmp_path):
+    steps = [
+        {'name': 'commit'},
+        {'name': 'push'},
+        {'name': 'pr'},
+    ]
+    config_path = _init_repo(tmp_path, push_policy='per_feature', sprint_length=None, steps=steps)
+
+    provider = SequencedProvider(['feat: update docs'])
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    push_calls: list[str] = []
+    pr_calls: list[str] = []
+
+    def fake_push(self):
+        push_calls.append('push')
+        return True
+
+    def fake_pr(self):
+        pr_calls.append('pr')
+        return True
+
+    monkeypatch.setattr(Douglas, '_run_git_push', fake_push)
+    monkeypatch.setattr(Douglas, '_open_pull_request', fake_pr)
+
+    douglas = Douglas(config_path)
+    readme = tmp_path / 'README.md'
+    readme.write_text('Initial content\nMore details\n', encoding='utf-8')
+
+    douglas.run_loop()
+
+    assert push_calls == ['push']
+    assert pr_calls == ['pr']
+
+
+def test_per_sprint_policy_defers_push_until_final_day(monkeypatch, tmp_path):
+    steps = [
+        {'name': 'commit'},
+        {'name': 'push'},
+    ]
+    config_path = _init_repo(tmp_path, push_policy='per_sprint', sprint_length=2, steps=steps)
+
+    provider = SequencedProvider(['feat: add first change', 'feat: add second change'])
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    push_calls: list[str] = []
+
+    def fake_push(self):
+        push_calls.append('push')
+        return True
+
+    monkeypatch.setattr(Douglas, '_run_git_push', fake_push)
+
+    douglas = Douglas(config_path)
+    readme = tmp_path / 'README.md'
+
+    readme.write_text('Initial content\nDay 1\n', encoding='utf-8')
+    douglas.run_loop()
+    assert push_calls == []
+
+    readme.write_text('Initial content\nDay 1\nDay 2\n', encoding='utf-8')
+    douglas.run_loop()
+    assert push_calls == ['push']

--- a/tests/test_push_policy.py
+++ b/tests/test_push_policy.py
@@ -67,14 +67,15 @@ def test_per_feature_policy_pushes_and_creates_pr(monkeypatch, tmp_path):
 
     def fake_push(self):
         push_calls.append('push')
-        return True
+        return True, 'pushed'
 
     def fake_pr(self):
         pr_calls.append('pr')
-        return True
+        return True, 'https://example.test/pr'
 
     monkeypatch.setattr(Douglas, '_run_git_push', fake_push)
     monkeypatch.setattr(Douglas, '_open_pull_request', fake_pr)
+    monkeypatch.setattr(Douglas, '_monitor_ci', lambda self: None)
 
     douglas = Douglas(config_path)
     readme = tmp_path / 'README.md'
@@ -100,9 +101,10 @@ def test_per_sprint_policy_defers_push_until_final_day(monkeypatch, tmp_path):
 
     def fake_push(self):
         push_calls.append('push')
-        return True
+        return True, 'pushed'
 
     monkeypatch.setattr(Douglas, '_run_git_push', fake_push)
+    monkeypatch.setattr(Douglas, '_monitor_ci', lambda self: None)
 
     douglas = Douglas(config_path)
     readme = tmp_path / 'README.md'

--- a/tests/test_review_step.py
+++ b/tests/test_review_step.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.core import Douglas
+
+
+class DummyProvider:
+    def __init__(self, response):
+        self.response = response
+        self.prompts: list[str] = []
+        self.called = False
+
+    def generate_code(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        self.called = True
+        return self.response
+
+
+def _write_basic_config(tmp_path: Path) -> Path:
+    config = (
+        "project:\n"
+        "  name: 'ReviewTest'\n"
+        "  language: 'python'\n"
+        "ai:\n"
+        "  provider: 'openai'\n"
+        "loop:\n"
+        "  steps: []\n"
+    )
+    config_path = tmp_path / 'douglas.yaml'
+    config_path.write_text(config, encoding='utf-8')
+    return config_path
+
+
+def test_review_invokes_llm_and_saves_feedback(monkeypatch, tmp_path, capsys):
+    config_path = _write_basic_config(tmp_path)
+    provider = DummyProvider("Looks good to me.")
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    douglas = Douglas(config_path)
+    monkeypatch.setattr(Douglas, '_get_pending_diff', lambda self: 'diff --git a/foo b/foo\n+print("hi")')
+
+    douglas.review()
+
+    captured = capsys.readouterr()
+    assert "Language model review feedback:" in captured.out
+    assert "Looks good to me." in captured.out
+
+    review_file = tmp_path / 'douglas_review.md'
+    assert review_file.exists()
+    content = review_file.read_text(encoding='utf-8')
+    assert "Looks good to me." in content
+    assert provider.prompts
+    assert "CHANGES TO REVIEW" in provider.prompts[0]
+
+
+def test_review_skips_when_no_diff(monkeypatch, tmp_path, capsys):
+    config_path = _write_basic_config(tmp_path)
+    provider = DummyProvider("Should not be used")
+    monkeypatch.setattr(Douglas, 'create_llm_provider', lambda self: provider)
+
+    douglas = Douglas(config_path)
+    monkeypatch.setattr(Douglas, '_get_pending_diff', lambda self: '')
+
+    douglas.review()
+
+    captured = capsys.readouterr()
+    assert "No code changes detected for review; skipping." in captured.out
+    assert not provider.called
+
+    review_file = tmp_path / 'douglas_review.md'
+    assert not review_file.exists()
+

--- a/tests/test_sprint_manager.py
+++ b/tests/test_sprint_manager.py
@@ -1,0 +1,77 @@
+from douglas.sprint_manager import SprintManager
+
+
+def test_per_sprint_cadence_runs_only_on_final_day():
+    manager = SprintManager(sprint_length_days=3)
+
+    decision = manager.should_run_step('demo', {'frequency': 'per_sprint'})
+    assert decision.should_run is False
+
+    manager.current_day = 3
+    decision = manager.should_run_step('demo', {'frequency': 'per_sprint'})
+    assert decision.should_run is True
+    assert decision.event_type == 'sprint'
+
+    manager.record_step_execution('demo', decision.event_type)
+    again = manager.should_run_step('demo', {'frequency': 'per_sprint'})
+    assert again.should_run is False
+
+
+def test_feature_events_are_consumed_per_step():
+    manager = SprintManager(sprint_length_days=5)
+    manager.record_commit('feat: first feature')
+
+    decision = manager.should_run_step('feature_refinement', {'frequency': 'per_feature'})
+    assert decision.should_run is True
+    assert decision.event_type == 'feature'
+
+    manager.record_step_execution('feature_refinement', decision.event_type)
+    follow_up = manager.should_run_step('feature_refinement', {'frequency': 'per_feature'})
+    assert follow_up.should_run is False
+
+    manager.record_commit('feat(ui): second feature')
+    third = manager.should_run_step('feature_refinement', {'frequency': 'per_feature'})
+    assert third.should_run is True
+
+
+def test_push_policy_per_feature_consumes_events():
+    manager = SprintManager(sprint_length_days=5)
+    manager.record_commit('feat: add capability')
+
+    decision = manager.should_run_push('per_feature')
+    assert decision.should_run is True
+    assert decision.event_type == 'feature'
+
+    manager.record_push(decision.event_type, 'per_feature')
+    after_push = manager.should_run_push('per_feature')
+    assert after_push.should_run is False
+
+
+def test_push_policy_per_sprint_waits_for_last_day():
+    manager = SprintManager(sprint_length_days=2)
+    manager.record_commit('feat: early work')
+
+    early = manager.should_run_push('per_sprint')
+    assert early.should_run is False
+
+    manager.current_day = 2
+    ready = manager.should_run_push('per_sprint')
+    assert ready.should_run is True
+    assert ready.event_type == 'sprint'
+
+    manager.record_push(ready.event_type, 'per_sprint')
+    repeat = manager.should_run_push('per_sprint')
+    assert repeat.should_run is False
+
+
+def test_pr_policy_tracks_commits():
+    manager = SprintManager(sprint_length_days=4)
+    manager.record_commit('fix: resolve issue')
+
+    decision = manager.should_open_pr('per_bug')
+    assert decision.should_run is True
+    assert decision.event_type == 'bug'
+
+    manager.record_pr(decision.event_type, 'per_bug')
+    follow_up = manager.should_open_pr('per_bug')
+    assert follow_up.should_run is False

--- a/tests/test_typecheck_pipeline.py
+++ b/tests/test_typecheck_pipeline.py
@@ -1,0 +1,60 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.pipelines import typecheck
+
+
+def _completed(command: list[str]):
+    return subprocess.CompletedProcess(command, 0)
+
+
+def test_run_typecheck_executes_all_commands(monkeypatch):
+    calls = []
+
+    def fake_run(command, check=True):
+        calls.append((tuple(command), check))
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    typecheck.run_typecheck(additional_commands=[['echo', 'ok']])
+
+    expected_commands = [
+        ('mypy', '.'),
+        ('echo', 'ok'),
+    ]
+    assert [call[0] for call in calls] == expected_commands
+    assert all(check is True for _, check in calls)
+
+
+def test_run_typecheck_fails_on_type_error(monkeypatch):
+    def fake_run(command, check=True):
+        if command[0] == 'mypy':
+            raise subprocess.CalledProcessError(returncode=2, cmd=command)
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        typecheck.run_typecheck()
+
+    assert exc_info.value.code == 2
+
+
+def test_run_typecheck_handles_missing_command(monkeypatch):
+    def fake_run(command, check=True):
+        if command[0] == 'mypy':
+            raise FileNotFoundError('mypy not found')
+        return _completed(command)
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        typecheck.run_typecheck()
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
- add a `review` step to the workflow that summarizes pending diffs, queries the LLM, and records the feedback for developers
- extend the core module with helpers to assemble a review prompt, collect git diffs, and persist language-model suggestions
- cover the review workflow with unit tests that exercise successful feedback capture and the skip path when nothing changed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec796e08c83268c1d5a2a2cda3d63