### PR TITLE
Resolve scaffold merge conflicts

### DIFF
--- a/douglas/cli.py
+++ b/douglas/cli.py
@@ -191,11 +191,7 @@ def init(
         help="Push policy to encode in the generated douglas.yaml.",
     ),
     sprint_length: int = typer.Option(
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
         Douglas.DEFAULT_SPRINT_LENGTH_DAYS,
-MERGE_CONFLICT=
-        10,
-MERGE_CONFLICT> main
         "--sprint-length",
         help="Sprint length (in iterations) to record in the generated douglas.yaml.",
     ),

--- a/douglas/core.py
+++ b/douglas/core.py
@@ -2862,7 +2862,6 @@ class Douglas:
             # Reserved for future interactive prompts; currently all scaffolding is non-interactive.
             pass
 
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
         if name:
             scaffold_name = name
         else:
@@ -2870,9 +2869,6 @@ MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
             if not resolved_name:
                 resolved_name = Path.cwd().resolve().name
             scaffold_name = resolved_name or "DouglasProject"
-MERGE_CONFLICT=
-        scaffold_name = name or (target_path.name or "DouglasProject")
-MERGE_CONFLICT> main
         normalized_template = (template or "python").strip().lower()
         if normalized_template not in {"python", "blank"}:
             print(
@@ -2887,7 +2883,6 @@ MERGE_CONFLICT> main
             )
             policy_candidate = "per_feature"
 
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
         sprint_length_value = (
             self.DEFAULT_SPRINT_LENGTH_DAYS
             if sprint_length is None
@@ -2899,14 +2894,6 @@ MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
                 f"defaulting to {self.DEFAULT_SPRINT_LENGTH_DAYS}."
             )
             sprint_length_value = self.DEFAULT_SPRINT_LENGTH_DAYS
-MERGE_CONFLICT=
-        sprint_length_value = 10 if sprint_length is None else int(sprint_length)
-        if sprint_length_value <= 0:
-            print(
-                f"Warning: sprint length '{sprint_length_value}' is invalid; defaulting to 10."
-            )
-            sprint_length_value = 10
-MERGE_CONFLICT> main
 
         ci_choice = (ci or "github").strip().lower()
         if ci_choice not in {"github", "none"}:
@@ -2928,12 +2915,6 @@ MERGE_CONFLICT> main
         default_language = str(configured_language or "python")
         language = "python" if normalized_template == "python" else default_language
 
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
-        package_slug = re.sub(r"[^a-zA-Z0-9]+", "-", scaffold_name.lower()).strip("-")
-        if not package_slug:
-            package_slug = "app"
-        package_name = package_slug.replace("-", "_")
-MERGE_CONFLICT=
         def _normalize_module_name(value: str) -> str:
             slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
             if not slug:
@@ -2941,7 +2922,6 @@ MERGE_CONFLICT=
             return slug.replace("-", "_")
 
         package_name = _normalize_module_name(scaffold_name)
-MERGE_CONFLICT> main
         module_name = "app"
 
         context = {

--- a/templates/init/python/Makefile.tpl
+++ b/templates/init/python/Makefile.tpl
@@ -1,16 +1,11 @@
 .PHONY: venv test
 
 venv:
-python -m venv .venv
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
-. .venv/bin/activate && pip install --upgrade pip && pip install -r requirements-dev.txt
-. .venv/bin/activate && pip install -e .
-MERGE_CONFLICT=
-. .venv/bin/activate && \
-    pip install --upgrade pip && \
-    pip install -r requirements-dev.txt && \
-    pip install -e .
-MERGE_CONFLICT> main
+	python -m venv .venv
+	. .venv/bin/activate && \
+		pip install --upgrade pip && \
+		pip install -r requirements-dev.txt && \
+		pip install -e .
 
 test:
-. .venv/bin/activate && pytest -q
+	. .venv/bin/activate && pytest -q

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -87,11 +87,7 @@ def test_init_project_creates_python_scaffold(monkeypatch, tmp_path):
     assert "OPENAI_API_KEY" in env_example
 
     pyproject_text = (target_dir / "pyproject.toml").read_text(encoding="utf-8")
-MERGE_CONFLICT< codex/implement-bootstrapping-command-and-readme-update
-    assert f"name = \"{target_dir.name.lower().replace('-', '_')}" in pyproject_text
-MERGE_CONFLICT=
     assert f"name = \"{target_dir.name.lower().replace('-', '_')}\"" in pyproject_text
-MERGE_CONFLICT> main
 
     requirements_text = (target_dir / "requirements-dev.txt").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary
- set the CLI `--sprint-length` default to `Douglas.DEFAULT_SPRINT_LENGTH_DAYS`
- ensure project scaffolding normalizes names and sprint length using Douglas defaults
- clean up the python template Makefile and align init project tests with the generated metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3975f5bf883269fa515a06c8c810e