### PR TITLE
feat: add multi-provider support and registry

### DIFF
--- a/douglas/core.py
+++ b/douglas/core.py
@@ -25,16 +25,16 @@ from douglas.pipelines import retro as retropipe
 from douglas.pipelines import security as securitypipe
 from douglas.pipelines import test as testpipe
 from douglas.pipelines import typecheck
-from douglas.providers.llm_provider import LLMProvider
-from douglas.providers.provider_registry import (
-    LLMProviderRegistry,
-    StaticLLMProviderRegistry,
-)
 from douglas.providers.claude_code_provider import ClaudeCodeProvider
 from douglas.providers.codex_provider import CodexProvider
 from douglas.providers.copilot_provider import CopilotProvider
 from douglas.providers.gemini_provider import GeminiProvider
+from douglas.providers.llm_provider import LLMProvider
 from douglas.providers.openai_provider import OpenAIProvider
+from douglas.providers.provider_registry import (
+    LLMProviderRegistry,
+    StaticLLMProviderRegistry,
+)
 from douglas.sprint_manager import CadenceDecision, SprintManager
 
 TEMPLATE_ROOT = Path(__file__).resolve().parent.parent / "templates"

--- a/douglas/core.py
+++ b/douglas/core.py
@@ -78,8 +78,7 @@ class DouglasSystemExit(SystemExit):
 
 
 TLS_ERROR_PATTERN = re.compile(
-    r"\btls\b[^\n]*(error|failed|failure|handshake|protocol)",
-    re.IGNORECASE
+    r"\btls\b[^\n]*(error|failed|failure|handshake|protocol)", re.IGNORECASE
 )
 
 
@@ -134,11 +133,13 @@ class Douglas:
         raw_vcs = self.config.get("vcs")
         if isinstance(raw_vcs, Mapping):
             vcs_config = raw_vcs
-        vcs_provider_name = vcs_config.get("provider") if isinstance(vcs_config, Mapping) else None
+        vcs_provider_name = (
+            vcs_config.get("provider") if isinstance(vcs_config, Mapping) else None
+        )
         self._repository_integration = resolve_repository_integration(vcs_provider_name)
-        self._repository_provider_name = getattr(
-            self._repository_integration, "name", "github"
-        ).strip().lower()
+        self._repository_provider_name = (
+            getattr(self._repository_integration, "name", "github").strip().lower()
+        )
 
         self._llm_registry = None
         self.lm_provider = self.create_llm_provider()
@@ -201,7 +202,9 @@ class Douglas:
             provider = None
         return provider or self.lm_provider
 
-    def _infer_ai_provider_from_config(self, ai_config: Mapping[str, Any]) -> Optional[str]:
+    def _infer_ai_provider_from_config(
+        self, ai_config: Mapping[str, Any]
+    ) -> Optional[str]:
         if not isinstance(ai_config, Mapping):
             return None
         candidate = ai_config.get("default_provider")
@@ -1625,9 +1628,9 @@ class Douglas:
         if integration is None:
             integration = resolve_repository_integration(None)
             self._repository_integration = integration
-            self._repository_provider_name = getattr(
-                integration, "name", "github"
-            ).strip().lower()
+            self._repository_provider_name = (
+                getattr(integration, "name", "github").strip().lower()
+            )
 
         try:
             metadata = integration.create_pull_request(
@@ -2966,9 +2969,6 @@ class Douglas:
             f"Missing initialization template: {missing_path}"
         ) from last_error
 
-
-
-
     def init_project(
         self,
         target: Union[str, Path] = ".",
@@ -3007,9 +3007,7 @@ class Douglas:
             scaffold_name = resolved_name or "DouglasProject"
         normalized_template = (template or "python").strip().lower()
         if normalized_template not in {"python", "blank"}:
-            print(
-                f"Warning: Unsupported template '{template}'; defaulting to python."
-            )
+            print(f"Warning: Unsupported template '{template}'; defaulting to python.")
             normalized_template = "python"
 
         policy_candidate = (push_policy or "per_feature").strip().lower()
@@ -3038,9 +3036,7 @@ class Douglas:
 
         license_choice = (license_type or "none").strip().lower()
         if license_choice not in {"none", "mit"}:
-            print(
-                f"Warning: Unsupported license '{license_type}'; defaulting to none."
-            )
+            print(f"Warning: Unsupported license '{license_type}'; defaulting to none.")
             license_choice = "none"
 
         configured_language = (
@@ -3080,7 +3076,9 @@ class Douglas:
             .strip()
             .lower()
         )
-        model_choice = ai_model or self._infer_ai_model_from_config(ai_config, provider_choice)
+        model_choice = ai_model or self._infer_ai_model_from_config(
+            ai_config, provider_choice
+        )
         if not model_choice:
             model_choice = self._default_model_for_provider(provider_choice)
 
@@ -3200,7 +3198,10 @@ class Douglas:
             if not git_dir.exists():
                 try:
                     subprocess.run(
-                        ["git", "init"], cwd=target_path, check=True, capture_output=True
+                        ["git", "init"],
+                        cwd=target_path,
+                        check=True,
+                        capture_output=True,
                     )
                     subprocess.run(
                         ["git", "add", "."],

--- a/douglas/integrations/repository.py
+++ b/douglas/integrations/repository.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Optional, Protocol
 
 from douglas.integrations.github import GitHub
 
@@ -53,7 +53,7 @@ class AzureDevOpsIntegration:
         return "Azure DevOps pull request stub created; manual follow-up required."
 
 
-def resolve_repository_integration(name: str | None) -> RepositoryIntegration:
+def resolve_repository_integration(name: Optional[str]) -> RepositoryIntegration:
     normalized = (name or "github").strip().lower()
     if normalized in {"github", "gh"}:
         return GitHubIntegration()

--- a/douglas/integrations/repository.py
+++ b/douglas/integrations/repository.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Protocol
 

--- a/douglas/integrations/repository.py
+++ b/douglas/integrations/repository.py
@@ -1,0 +1,70 @@
+"""Repository provider abstractions for pull-request style interactions."""
+
+from __future__ import annotations
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from douglas.integrations.github import GitHub
+
+
+class RepositoryIntegration(Protocol):
+    """Lightweight protocol implemented by VCS providers."""
+
+    name: str
+    supports_ci_monitoring: bool
+
+    def create_pull_request(self, title: str, body: str, base: str, head: str) -> str:
+        """Create a pull request (or equivalent) and return provider metadata."""
+
+
+@dataclass
+class GitHubIntegration:
+    name: str = "github"
+    supports_ci_monitoring: bool = True
+
+    def create_pull_request(self, title: str, body: str, base: str, head: str) -> str:
+        return GitHub.create_pull_request(title=title, body=body, base=base, head=head)
+
+
+@dataclass
+class GitLabIntegration:
+    name: str = "gitlab"
+    supports_ci_monitoring: bool = False
+
+    def create_pull_request(self, title: str, body: str, base: str, head: str) -> str:
+        print(
+            "GitLab integration is currently stubbed. Use the GitLab CLI (glab) or UI "
+            "to open a merge request."
+        )
+        return "GitLab merge request stub created; manual follow-up required."
+
+
+@dataclass
+class AzureDevOpsIntegration:
+    name: str = "azure-devops"
+    supports_ci_monitoring: bool = False
+
+    def create_pull_request(self, title: str, body: str, base: str, head: str) -> str:
+        print(
+            "Azure DevOps integration is currently stubbed. Use the Azure CLI or UI "
+            "to open a pull request."
+        )
+        return "Azure DevOps pull request stub created; manual follow-up required."
+
+
+def resolve_repository_integration(name: str | None) -> RepositoryIntegration:
+    normalized = (name or "github").strip().lower()
+    if normalized in {"github", "gh"}:
+        return GitHubIntegration()
+    if normalized in {"gitlab", "gl"}:
+        return GitLabIntegration()
+    if normalized in {"azure", "azure-devops", "azure_devops", "azuredevops"}:
+        return AzureDevOpsIntegration()
+
+    print(
+        f"Warning: Unknown repository provider '{name}'. Falling back to GitHub integration."
+    )
+    return GitHubIntegration()

--- a/douglas/providers/claude_code_provider.py
+++ b/douglas/providers/claude_code_provider.py
@@ -29,9 +29,7 @@ class ClaudeCodeProvider(LLMProvider):
             or self.DEFAULT_MODEL
         )
         self._api_key = (
-            api_key
-            or os.getenv("ANTHROPIC_API_KEY")
-            or os.getenv("CLAUDE_API_KEY")
+            api_key or os.getenv("ANTHROPIC_API_KEY") or os.getenv("CLAUDE_API_KEY")
         )
         self._max_tokens = max_tokens or 4096
         self._client: Optional[Any] = None
@@ -132,6 +130,8 @@ class ClaudeCodeProvider(LLMProvider):
         return ""
 
     def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
-        print("[ClaudeCodeProvider] Falling back to placeholder output. Prompt preview:")
+        print(
+            "[ClaudeCodeProvider] Falling back to placeholder output. Prompt preview:"
+        )
         print(prompt[:200])
         return "# Claude Code API unavailable; no code generated."

--- a/douglas/providers/claude_code_provider.py
+++ b/douglas/providers/claude_code_provider.py
@@ -1,0 +1,137 @@
+"""Claude Code provider that gracefully degrades to a local stub when unavailable."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+from douglas.providers.llm_provider import LLMProvider
+
+
+class ClaudeCodeProvider(LLMProvider):
+    """Concrete provider for Anthropic's Claude Code models."""
+
+    DEFAULT_MODEL = "claude-3-5-sonnet-20240620"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        *,
+        max_tokens: Optional[int] = None,
+    ) -> None:
+        self.model = (
+            model_name
+            or os.getenv("CLAUDE_CODE_MODEL")
+            or os.getenv("ANTHROPIC_MODEL")
+            or self.DEFAULT_MODEL
+        )
+        self._api_key = (
+            api_key
+            or os.getenv("ANTHROPIC_API_KEY")
+            or os.getenv("CLAUDE_API_KEY")
+        )
+        self._max_tokens = max_tokens or 4096
+        self._client: Optional[Any] = None
+
+        if not self._api_key:
+            print(
+                "Warning: ANTHROPIC_API_KEY not set. Falling back to Claude Code stub output."
+            )
+            return
+
+        try:
+            anthropic = importlib.import_module("anthropic")
+        except ImportError:
+            print(
+                "Warning: The 'anthropic' package is not installed. Install it with "
+                "'pip install anthropic' to enable Claude Code integration."
+            )
+            return
+
+        client_factory = getattr(anthropic, "Anthropic", None)
+        if client_factory is None:
+            print(
+                "Warning: Anthropic SDK does not expose an Anthropic client. "
+                "Falling back to Claude Code stub output."
+            )
+            return
+
+        try:
+            self._client = client_factory(api_key=self._api_key)
+        except Exception as exc:  # pragma: no cover - defensive against SDK issues
+            print(f"Warning: Failed to initialise Anthropic client: {exc}")
+            self._client = None
+
+    def generate_code(self, prompt: str) -> str:
+        if not self._client:
+            return self._fallback(prompt)
+
+        try:
+            response = self._client.messages.create(
+                model=self.model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception as exc:  # pragma: no cover - network/SDK failures
+            print(
+                f"Warning: Claude Code request failed ({exc}). Falling back to stub output."
+            )
+            return self._fallback(prompt)
+
+        text = self._extract_text(response)
+        if text:
+            return text
+
+        print(
+            "Warning: Received empty response from Claude Code. Falling back to stub output."
+        )
+        return self._fallback(prompt)
+
+    def _extract_text(self, response: Any) -> str:
+        content = getattr(response, "content", None)
+        text = self._coerce_content(content)
+        if text:
+            return text
+
+        if isinstance(response, Mapping):
+            return self._coerce_content(response.get("content"))
+
+        return ""
+
+    def _coerce_content(self, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            stripped = content.strip()
+            return stripped if stripped else ""
+        if isinstance(content, Mapping):
+            if content.get("type") == "text":
+                value = content.get("text")
+                if isinstance(value, str):
+                    stripped = value.strip()
+                    if stripped:
+                        return stripped
+            collected: list[str] = []
+            for value in content.values():
+                piece = self._coerce_content(value)
+                if piece:
+                    collected.append(piece)
+            return "\n".join(collected).strip()
+        if isinstance(content, Sequence) and not isinstance(
+            content, (str, bytes, bytearray)
+        ):
+            items: list[str] = []
+            for item in content:
+                piece = self._coerce_content(item)
+                if piece:
+                    items.append(piece)
+            return "\n".join(items).strip()
+        return ""
+
+    def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
+        print("[ClaudeCodeProvider] Falling back to placeholder output. Prompt preview:")
+        print(prompt[:200])
+        return "# Claude Code API unavailable; no code generated."

--- a/douglas/providers/claude_code_provider.py
+++ b/douglas/providers/claude_code_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Mapping, Sequence
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from douglas.providers.llm_provider import LLMProvider
 
@@ -112,7 +112,7 @@ class ClaudeCodeProvider(LLMProvider):
                     stripped = value.strip()
                     if stripped:
                         return stripped
-            collected: list[str] = []
+            collected: List[str] = []
             for value in content.values():
                 piece = self._coerce_content(value)
                 if piece:
@@ -121,7 +121,7 @@ class ClaudeCodeProvider(LLMProvider):
         if isinstance(content, Sequence) and not isinstance(
             content, (str, bytes, bytearray)
         ):
-            items: list[str] = []
+            items: List[str] = []
             for item in content:
                 piece = self._coerce_content(item)
                 if piece:

--- a/douglas/providers/codex_provider.py
+++ b/douglas/providers/codex_provider.py
@@ -1,0 +1,37 @@
+"""Codex provider built on top of the OpenAI provider implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from douglas.providers.openai_provider import OpenAIProvider
+
+
+class CodexProvider(OpenAIProvider):
+    """LLM provider that targets the (legacy) OpenAI Codex models."""
+
+    DEFAULT_MODEL = "code-davinci-002"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        resolved_model = (
+            model_name
+            or os.getenv("OPENAI_CODEX_MODEL")
+            or os.getenv("OPENAI_MODEL")
+            or self.DEFAULT_MODEL
+        )
+        super().__init__(
+            model_name=resolved_model,
+            api_key=api_key,
+            base_url=base_url,
+        )
+
+    def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
+        print("[CodexProvider] Falling back to placeholder output. Prompt preview:")
+        print(prompt[:200])
+        return "# Codex API unavailable; no code generated."

--- a/douglas/providers/copilot_provider.py
+++ b/douglas/providers/copilot_provider.py
@@ -24,9 +24,7 @@ class CopilotProvider(LLMProvider):
         model_name: Optional[str] = None,
         token: Optional[str] = None,
     ) -> None:
-        self.model = (
-            model_name or os.getenv("COPILOT_MODEL") or self.DEFAULT_MODEL
-        )
+        self.model = model_name or os.getenv("COPILOT_MODEL") or self.DEFAULT_MODEL
         self._token = token or os.getenv("COPILOT_TOKEN") or os.getenv("GITHUB_TOKEN")
         if not self._token:
             print(
@@ -37,6 +35,8 @@ class CopilotProvider(LLMProvider):
         return self._fallback(prompt)
 
     def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
-        print("[CopilotProvider] GitHub Copilot integration is stubbed. Prompt preview:")
+        print(
+            "[CopilotProvider] GitHub Copilot integration is stubbed. Prompt preview:"
+        )
         print(prompt[:200])
         return "# GitHub Copilot API unavailable; no code generated."

--- a/douglas/providers/copilot_provider.py
+++ b/douglas/providers/copilot_provider.py
@@ -1,0 +1,42 @@
+"""GitHub Copilot provider stub that emits deterministic placeholder responses."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from douglas.providers.llm_provider import LLMProvider
+
+
+class CopilotProvider(LLMProvider):
+    """Stubbed provider for GitHub Copilot.
+
+    GitHub Copilot does not currently expose a stable public API. This provider
+    exists so Douglas can be configured with Copilot-style roles while falling
+    back to deterministic placeholder output. When official APIs become
+    available the implementation can be swapped without impacting callers.
+    """
+
+    DEFAULT_MODEL = "gpt-4o-copilot"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> None:
+        self.model = (
+            model_name or os.getenv("COPILOT_MODEL") or self.DEFAULT_MODEL
+        )
+        self._token = token or os.getenv("COPILOT_TOKEN") or os.getenv("GITHUB_TOKEN")
+        if not self._token:
+            print(
+                "Warning: GitHub Copilot token not configured. Falling back to Copilot stub output."
+            )
+
+    def generate_code(self, prompt: str) -> str:
+        return self._fallback(prompt)
+
+    def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
+        print("[CopilotProvider] GitHub Copilot integration is stubbed. Prompt preview:")
+        print(prompt[:200])
+        return "# GitHub Copilot API unavailable; no code generated."

--- a/douglas/providers/gemini_provider.py
+++ b/douglas/providers/gemini_provider.py
@@ -1,0 +1,145 @@
+"""Google Gemini provider with graceful fallback behaviour."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+from douglas.providers.llm_provider import LLMProvider
+
+
+class GeminiProvider(LLMProvider):
+    """Provider implementation backed by the google-generativeai SDK."""
+
+    DEFAULT_MODEL = "gemini-1.5-flash"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        *,
+        client: Optional[Any] = None,
+    ) -> None:
+        self.model = (
+            model_name
+            or os.getenv("GEMINI_MODEL")
+            or os.getenv("GOOGLE_MODEL")
+            or self.DEFAULT_MODEL
+        )
+        self._api_key = (
+            api_key
+            or os.getenv("GEMINI_API_KEY")
+            or os.getenv("GOOGLE_API_KEY")
+        )
+        self._client: Optional[Any] = client
+
+        if self._client is not None:
+            return
+
+        try:
+            genai = importlib.import_module("google.generativeai")
+        except ImportError:
+            print(
+                "Warning: The 'google-generativeai' package is not installed. Install it "
+                "with 'pip install google-generativeai' to enable Gemini integration."
+            )
+            return
+
+        if not self._api_key:
+            print(
+                "Warning: GEMINI_API_KEY not set. Falling back to Gemini stub output."
+            )
+            return
+
+        try:
+            configure = getattr(genai, "configure", None)
+            if callable(configure):
+                configure(api_key=self._api_key)
+            client_factory = getattr(genai, "GenerativeModel", None)
+            if client_factory is None:
+                print(
+                    "Warning: google-generativeai SDK does not expose GenerativeModel. "
+                    "Falling back to Gemini stub output."
+                )
+                return
+            self._client = client_factory(self.model)
+        except Exception as exc:  # pragma: no cover - defensive against SDK issues
+            print(f"Warning: Failed to initialise Gemini client: {exc}")
+            self._client = None
+
+    def generate_code(self, prompt: str) -> str:
+        if not self._client:
+            return self._fallback(prompt)
+
+        try:
+            response = self._client.generate_content(prompt)
+        except Exception as exc:  # pragma: no cover - network/SDK failures
+            print(
+                f"Warning: Gemini request failed ({exc}). Falling back to stub output."
+            )
+            return self._fallback(prompt)
+
+        text = self._extract_text(response)
+        if text:
+            return text
+
+        print(
+            "Warning: Received empty response from Gemini. Falling back to stub output."
+        )
+        return self._fallback(prompt)
+
+    def _extract_text(self, response: Any) -> str:
+        direct_text = getattr(response, "text", None)
+        if isinstance(direct_text, str) and direct_text.strip():
+            return direct_text.strip()
+
+        content = getattr(response, "content", None)
+        text = self._coerce_content(content)
+        if text:
+            return text
+
+        candidates = getattr(response, "candidates", None)
+        if candidates:
+            return self._coerce_content(candidates)
+
+        if isinstance(response, Mapping):
+            return self._coerce_content(response.get("content"))
+
+        return ""
+
+    def _coerce_content(self, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            stripped = content.strip()
+            return stripped if stripped else ""
+        if isinstance(content, Mapping):
+            aggregated: list[str] = []
+            for value in content.values():
+                piece = self._coerce_content(value)
+                if piece:
+                    aggregated.append(piece)
+            return "\n".join(aggregated).strip()
+        if isinstance(content, Sequence) and not isinstance(
+            content, (str, bytes, bytearray)
+        ):
+            pieces: list[str] = []
+            for item in content:
+                # Gemini responses often nest content under parts with "text" attributes.
+                if hasattr(item, "text"):
+                    text = getattr(item, "text")
+                    if isinstance(text, str) and text.strip():
+                        pieces.append(text.strip())
+                        continue
+                piece = self._coerce_content(item)
+                if piece:
+                    pieces.append(piece)
+            return "\n".join(pieces).strip()
+        return ""
+
+    def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
+        print("[GeminiProvider] Falling back to placeholder output. Prompt preview:")
+        print(prompt[:200])
+        return "# Gemini API unavailable; no code generated."

--- a/douglas/providers/gemini_provider.py
+++ b/douglas/providers/gemini_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Mapping, Sequence
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from douglas.providers.llm_provider import LLMProvider
 
@@ -114,7 +114,7 @@ class GeminiProvider(LLMProvider):
             stripped = content.strip()
             return stripped if stripped else ""
         if isinstance(content, Mapping):
-            aggregated: list[str] = []
+            aggregated: List[str] = []
             for value in content.values():
                 piece = self._coerce_content(value)
                 if piece:
@@ -123,7 +123,7 @@ class GeminiProvider(LLMProvider):
         if isinstance(content, Sequence) and not isinstance(
             content, (str, bytes, bytearray)
         ):
-            pieces: list[str] = []
+            pieces: List[str] = []
             for item in content:
                 # Gemini responses often nest content under parts with "text" attributes.
                 if hasattr(item, "text"):

--- a/douglas/providers/gemini_provider.py
+++ b/douglas/providers/gemini_provider.py
@@ -29,9 +29,7 @@ class GeminiProvider(LLMProvider):
             or self.DEFAULT_MODEL
         )
         self._api_key = (
-            api_key
-            or os.getenv("GEMINI_API_KEY")
-            or os.getenv("GOOGLE_API_KEY")
+            api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         )
         self._client: Optional[Any] = client
 

--- a/douglas/providers/llm_provider.py
+++ b/douglas/providers/llm_provider.py
@@ -8,13 +8,36 @@ class LLMProvider(ABC):
 
     @staticmethod
     def create_provider(name: str, **options):
-        normalized = (name or "").lower()
-        if normalized == "openai":
+        normalized = (name or "").strip().lower()
+
+        model = options.get("model") or options.get("model_name")
+        api_key = options.get("api_key") or options.get("token")
+        base_url = options.get("base_url") or options.get("api_base")
+
+        if normalized in {"openai", "gpt", "gpt-4", "gpt4"}:
             from douglas.providers.openai_provider import OpenAIProvider
 
-            model = options.get("model")
-            api_key = options.get("api_key")
-            base_url = options.get("base_url") or options.get("api_base")
             return OpenAIProvider(model_name=model, api_key=api_key, base_url=base_url)
+
+        if normalized in {"codex", "openai-codex", "codex-openai", "code-davinci"}:
+            from douglas.providers.codex_provider import CodexProvider
+
+            return CodexProvider(model_name=model, api_key=api_key, base_url=base_url)
+
+        if normalized in {"claude", "claude_code", "claude-code", "anthropic"}:
+            from douglas.providers.claude_code_provider import ClaudeCodeProvider
+
+            return ClaudeCodeProvider(model_name=model, api_key=api_key)
+
+        if normalized in {"gemini", "google", "google-ai", "googleai"}:
+            from douglas.providers.gemini_provider import GeminiProvider
+
+            return GeminiProvider(model_name=model, api_key=api_key)
+
+        if normalized in {"copilot", "github-copilot", "github"}:
+            from douglas.providers.copilot_provider import CopilotProvider
+
+            token = options.get("token") or api_key
+            return CopilotProvider(model_name=model, token=token)
 
         raise ValueError(f"Unsupported LLM provider: {name}")

--- a/douglas/providers/provider_registry.py
+++ b/douglas/providers/provider_registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from douglas.providers.codex_provider import CodexProvider
 from douglas.providers.llm_provider import LLMProvider
@@ -212,7 +212,7 @@ class LLMProviderRegistry:
         key: str,
         provider: LLMProvider,
         *,
-        aliases: Optional[set[str]] = None,
+        aliases: Optional[Set[str]] = None,
     ) -> str:
         canonical = self._normalize(key) or f"provider_{len(self._providers)}"
         self._providers[canonical] = provider

--- a/douglas/providers/provider_registry.py
+++ b/douglas/providers/provider_registry.py
@@ -1,0 +1,223 @@
+"""Utilities for configuring and resolving language model providers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Dict, Optional
+
+from douglas.providers.codex_provider import CodexProvider
+from douglas.providers.llm_provider import LLMProvider
+
+
+class StaticLLMProviderRegistry:
+    """Minimal registry used when tests monkeypatch ``create_llm_provider``."""
+
+    def __init__(self, provider: LLMProvider) -> None:
+        self._provider = provider
+
+    @property
+    def default_provider(self) -> LLMProvider:
+        return self._provider
+
+    def resolve(self, agent_label: str, step_name: str) -> LLMProvider:
+        return self._provider
+
+
+class LLMProviderRegistry:
+    """Registry that supports multiple providers and per-agent assignments."""
+
+    def __init__(self, config: Optional[Mapping[str, Any]] = None) -> None:
+        self._providers: Dict[str, LLMProvider] = {}
+        self._aliases: Dict[str, str] = {}
+        self._assignments: Dict[str, Dict[str, str]] = {}
+        self._default_key: Optional[str] = None
+
+        self._initialize(config or {})
+
+        if not self._providers:
+            fallback = CodexProvider()
+            self._register_provider("codex", fallback, aliases={"codex", "default"})
+            self._default_key = "codex"
+
+        if self._default_key is None:
+            self._default_key = next(iter(self._providers), None)
+
+        if self._default_key is not None:
+            self._aliases.setdefault("default", self._default_key)
+
+    @property
+    def default_provider(self) -> LLMProvider:
+        if self._default_key and self._default_key in self._providers:
+            return self._providers[self._default_key]
+        return next(iter(self._providers.values()))
+
+    def resolve(self, agent_label: str, step_name: str) -> LLMProvider:
+        agent_key = self._normalize(agent_label)
+        step_key = self._normalize(step_name)
+
+        if agent_key:
+            agent_map = self._assignments.get(agent_key)
+            if agent_map:
+                candidate_key = agent_map.get(step_key) or agent_map.get("*")
+                if candidate_key and candidate_key in self._providers:
+                    return self._providers[candidate_key]
+
+        return self.default_provider
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _initialize(self, config: Mapping[str, Any]) -> None:
+        providers_cfg = config.get("providers")
+        if isinstance(providers_cfg, Mapping):
+            for label, spec in providers_cfg.items():
+                self._load_named_provider(label, spec)
+
+        top_level_provider = config.get("provider")
+        if isinstance(top_level_provider, str) and top_level_provider.strip():
+            sanitized = {
+                key: value
+                for key, value in config.items()
+                if key
+                not in {"provider", "providers", "default_provider", "assignments", "prompt"}
+            }
+            canonical = self._lookup_or_create(top_level_provider, sanitized)
+            if canonical:
+                self._aliases["default"] = canonical
+                if self._default_key is None:
+                    self._default_key = canonical
+
+        default_provider_name = config.get("default_provider")
+        if isinstance(default_provider_name, str) and default_provider_name.strip():
+            canonical = self._lookup_or_create(default_provider_name, {})
+            if canonical:
+                self._default_key = canonical
+
+        assignments_cfg = config.get("assignments")
+        if isinstance(assignments_cfg, Mapping):
+            for agent, mapping in assignments_cfg.items():
+                self._load_assignment(agent, mapping)
+
+    def _load_named_provider(self, label: str, spec: Any) -> None:
+        if not isinstance(spec, Mapping):
+            raise ValueError(
+                f"Provider entry '{label}' must be a mapping of options to values."
+            )
+
+        provider_name = spec.get("provider") or spec.get("type") or label
+        options = {
+            key: value
+            for key, value in spec.items()
+            if key not in {"provider", "type", "aliases", "default"}
+        }
+        aliases = set()
+        raw_aliases = spec.get("aliases")
+        if isinstance(raw_aliases, str):
+            aliases.add(raw_aliases)
+        elif isinstance(raw_aliases, Mapping):
+            aliases.update(str(item) for item in raw_aliases.values())
+        elif isinstance(raw_aliases, (list, set, tuple)):
+            aliases.update(str(item) for item in raw_aliases)
+
+        canonical = self._lookup_or_create(provider_name, options, preferred_key=label)
+        if canonical:
+            aliases.update({label, provider_name})
+            if spec.get("default"):
+                self._default_key = canonical
+            self._aliases.setdefault("default", self._default_key or canonical)
+            for alias in aliases:
+                normalized = self._normalize(alias)
+                if normalized:
+                    self._aliases[normalized] = canonical
+
+    def _load_assignment(self, agent: str, mapping: Any) -> None:
+        normalized_agent = self._normalize(agent)
+        if not normalized_agent:
+            return
+
+        agent_map: Dict[str, str] = {}
+        if isinstance(mapping, Mapping):
+            for step, provider_ref in mapping.items():
+                normalized_step = self._normalize(step) or "*"
+                canonical = self._resolve_assignment_provider(provider_ref)
+                if canonical:
+                    agent_map[normalized_step] = canonical
+        elif isinstance(mapping, str):
+            canonical = self._resolve_assignment_provider(mapping)
+            if canonical:
+                agent_map["*"] = canonical
+
+        if agent_map:
+            self._assignments[normalized_agent] = agent_map
+
+    def _resolve_assignment_provider(self, reference: Any) -> Optional[str]:
+        if isinstance(reference, Mapping):
+            provider_name = reference.get("provider") or reference.get("type")
+            if not provider_name:
+                return None
+            options = {
+                key: value for key, value in reference.items() if key not in {"provider", "type"}
+            }
+            return self._lookup_or_create(provider_name, options)
+        if isinstance(reference, str):
+            return self._lookup_or_create(reference, {})
+        return None
+
+    def _lookup_or_create(
+        self,
+        provider_name: str,
+        options: Mapping[str, Any],
+        *,
+        preferred_key: Optional[str] = None,
+    ) -> Optional[str]:
+        normalized = self._normalize(provider_name)
+        if not normalized:
+            return None
+
+        canonical = self._aliases.get(normalized)
+        if canonical:
+            return canonical
+
+        provider = self._instantiate_provider(provider_name, options)
+        key = preferred_key or provider_name
+        return self._register_provider(key, provider, aliases={provider_name})
+
+    def _instantiate_provider(
+        self, provider_name: str, options: Mapping[str, Any]
+    ) -> LLMProvider:
+        sanitized = {
+            key: value
+            for key, value in options.items()
+            if key not in {"aliases", "default"} and value is not None
+        }
+        if "model" in sanitized and "model_name" not in sanitized:
+            sanitized["model_name"] = sanitized["model"]
+        try:
+            return LLMProvider.create_provider(provider_name, **sanitized)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unsupported LLM provider '{provider_name}': {exc}"
+            ) from exc
+
+    def _register_provider(
+        self,
+        key: str,
+        provider: LLMProvider,
+        *,
+        aliases: Optional[set[str]] = None,
+    ) -> str:
+        canonical = self._normalize(key) or f"provider_{len(self._providers)}"
+        self._providers[canonical] = provider
+
+        alias_set = {canonical}
+        if aliases:
+            alias_set.update(self._normalize(alias) for alias in aliases if alias)
+
+        for alias in alias_set:
+            self._aliases[alias] = canonical
+
+        return canonical
+
+    @staticmethod
+    def _normalize(value: Any) -> str:
+        return str(value).strip().lower() if value is not None else ""

--- a/douglas/providers/provider_registry.py
+++ b/douglas/providers/provider_registry.py
@@ -79,7 +79,13 @@ class LLMProviderRegistry:
                 key: value
                 for key, value in config.items()
                 if key
-                not in {"provider", "providers", "default_provider", "assignments", "prompt"}
+                not in {
+                    "provider",
+                    "providers",
+                    "default_provider",
+                    "assignments",
+                    "prompt",
+                }
             }
             canonical = self._lookup_or_create(top_level_provider, sanitized)
             if canonical:
@@ -156,7 +162,9 @@ class LLMProviderRegistry:
             if not provider_name:
                 return None
             options = {
-                key: value for key, value in reference.items() if key not in {"provider", "type"}
+                key: value
+                for key, value in reference.items()
+                if key not in {"provider", "type"}
             }
             return self._lookup_or_create(provider_name, options)
         if isinstance(reference, str):

--- a/douglas/sprint_manager.py
+++ b/douglas/sprint_manager.py
@@ -228,9 +228,7 @@ class SprintManager:
         if identifier:
             self.completed_features.add(str(identifier))
 
-    def mark_feature_ready_for_release(
-        self, identifier: Optional[str] = None
-    ) -> None:
+    def mark_feature_ready_for_release(self, identifier: Optional[str] = None) -> None:
         self.pending_events["feature_complete"] += 1
         if identifier:
             self.release_ready_features.add(str(identifier))
@@ -288,9 +286,7 @@ class SprintManager:
             )
 
         if policy == "per_feature_complete":
-            available = self._available_event_for_consumer(
-                "feature_complete", "push"
-            )
+            available = self._available_event_for_consumer("feature_complete", "push")
             if available > 0:
                 plural = "s" if available != 1 else ""
                 return CadenceDecision(
@@ -371,9 +367,7 @@ class SprintManager:
             )
 
         if policy == "per_feature_complete":
-            available = self._available_event_for_consumer(
-                "feature_complete", "pr"
-            )
+            available = self._available_event_for_consumer("feature_complete", "pr")
             if available > 0:
                 plural = "s" if available != 1 else ""
                 return CadenceDecision(

--- a/templates/douglas.yaml.tpl
+++ b/templates/douglas.yaml.tpl
@@ -4,8 +4,11 @@ project:
   license: "MIT"
   language: "python"
 ai:
-  provider: "openai"
-  model: "gpt-4"
+  default_provider: "codex"
+  providers:
+    codex:
+      provider: "codex"
+      model: "code-davinci-002"
   prompt: "system_prompt.md"
 cadence:
   Developer:

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,14 +1,11 @@
-import sys
 from pathlib import Path
 
 import yaml
 from typer.testing import CliRunner
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from douglas import cli as cli_module  # noqa: E402
-from douglas.cli import app  # noqa: E402
-from douglas.core import Douglas  # noqa: E402
+from douglas import cli as cli_module
+from douglas.cli import app
+from douglas.core import Douglas
 
 
 def test_cli_init_without_config(monkeypatch, tmp_path):

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -1,13 +1,9 @@
 import subprocess
-import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import List, Optional
 
 import yaml
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from types import SimpleNamespace
 
 from douglas.core import Douglas
 from douglas.pipelines import demo as demo_pipeline

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -87,7 +87,7 @@ def test_init_project_creates_python_scaffold(monkeypatch, tmp_path):
     assert "OPENAI_API_KEY" in env_example
 
     pyproject_text = (target_dir / "pyproject.toml").read_text(encoding="utf-8")
-    assert f"name = \"{target_dir.name.lower().replace('-', '_')}\"" in pyproject_text
+    assert f'name = "{target_dir.name.lower().replace("-", "_")}"' in pyproject_text
 
     requirements_text = (target_dir / "requirements-dev.txt").read_text(
         encoding="utf-8"

--- a/tests/test_llm_registry.py
+++ b/tests/test_llm_registry.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from douglas.providers.claude_code_provider import ClaudeCodeProvider
+from douglas.providers.codex_provider import CodexProvider
+from douglas.providers.gemini_provider import GeminiProvider
+from douglas.providers.provider_registry import LLMProviderRegistry
+
+
+def test_registry_defaults_to_codex():
+    registry = LLMProviderRegistry({})
+    provider = registry.default_provider
+    assert isinstance(provider, CodexProvider)
+    assert registry.resolve("Developer", "generate") is provider
+
+
+def test_registry_respects_assignments():
+    config = {
+        "default_provider": "codex",
+        "providers": {
+            "codex": {"provider": "codex"},
+            "claude": {"provider": "claude_code"},
+        },
+        "assignments": {
+            "developer": {"review": "claude"},
+        },
+    }
+    registry = LLMProviderRegistry(config)
+    assert isinstance(registry.resolve("Developer", "review"), ClaudeCodeProvider)
+    assert isinstance(registry.resolve("Developer", "generate"), CodexProvider)
+
+
+def test_registry_instantiates_providers_from_assignments():
+    config = {
+        "default_provider": "codex",
+        "assignments": {"tester": {"test": "gemini"}},
+    }
+    registry = LLMProviderRegistry(config)
+    assert isinstance(registry.resolve("Tester", "test"), GeminiProvider)

--- a/tests/test_llm_registry.py
+++ b/tests/test_llm_registry.py
@@ -1,9 +1,3 @@
-from pathlib import Path
-
-import sys
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 from douglas.providers.claude_code_provider import ClaudeCodeProvider
 from douglas.providers.codex_provider import CodexProvider
 from douglas.providers.gemini_provider import GeminiProvider

--- a/tests/test_push_policy.py
+++ b/tests/test_push_policy.py
@@ -177,9 +177,7 @@ def test_per_feature_complete_policy_pushes_after_feature_completion(
     assert push_calls == ["push"]
 
 
-def test_per_feature_complete_policy_skips_non_feature_commits(
-    monkeypatch, tmp_path
-):
+def test_per_feature_complete_policy_skips_non_feature_commits(monkeypatch, tmp_path):
     steps = [
         {"name": "commit"},
         {"name": "push"},


### PR DESCRIPTION
## Summary
- introduce an LLM provider registry, defaulting to Codex, with support for Claude Code, Gemini, Copilot and OpenAI models
- add CLI and template updates so projects can choose providers during init, and document the new options in the README
- add repository integrations for GitHub/GitLab/Azure DevOps (via gh or stubbed messaging) and expand the test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a0f111e88326a04af7c55c42a1dd