### PR TITLE
style: format core and exit condition tests

### DIFF
--- a/douglas/core.py
+++ b/douglas/core.py
@@ -160,9 +160,9 @@ class Douglas:
         self._ci_monitoring_deferred: bool = False
         self._configured_steps: set[str] = set()
         self._executed_step_names: set[str] = set()
-        self._blocking_questions_by_role: Dict[
-            str, List[question_journal.Question]
-        ] = {}
+        self._blocking_questions_by_role: Dict[str, List[question_journal.Question]] = (
+            {}
+        )
         self._run_state_path = self._resolve_run_state_path()
         self._soft_stop_pending = False
 
@@ -769,8 +769,9 @@ class Douglas:
     def _exit_conditions_met(self, executed_steps: List[str]) -> bool:
         exit_conditions = self.config.get("loop", {}).get("exit_conditions") or []
         for condition in exit_conditions:
-            if condition == "sprint_demo_complete" and self.sprint_manager.has_step_run(
-                "demo"
+            if (
+                condition == "sprint_demo_complete"
+                and self.sprint_manager.has_step_run("demo")
             ):
                 return True
             if condition == "tests_pass" and self._loop_outcomes.get("test") is True:

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -99,9 +99,9 @@ def test_exit_condition_allows_remaining_steps(monkeypatch, tmp_path):
     douglas.run_loop()
 
     assert test_calls == ["test"], "Test step should execute exactly once."
-    assert push_calls == ["push"], (
-        "Push step should still execute despite exit condition."
-    )
+    assert push_calls == [
+        "push"
+    ], "Push step should still execute despite exit condition."
 
 
 def test_exit_condition_stops_additional_iterations(monkeypatch, tmp_path):
@@ -150,9 +150,7 @@ def test_loop_repeats_until_iteration_limit(monkeypatch, tmp_path):
     assert test_calls == [
         "test",
         "test",
-    ], (
-        "Loop should run for the configured iteration limit when exit conditions are absent."
-    )
+    ], "Loop should run for the configured iteration limit when exit conditions are absent."
 
 
 def test_exit_condition_for_demo_completion(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- format `douglas/core.py` with Black so multiline assignments and conditionals follow project style
- format `tests/test_exit_conditions.py` to satisfy Black's preferred assertion layout

## Testing
- PYTHONPATH=. pytest tests/test_exit_conditions.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e82e35a0832688a0bf8815371506