### PR TITLE
Default to Codex CLI authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Douglas ships with a turnkey `douglas init` command that creates a ready-to-run 
 douglas init my-app --template python --non-interactive
 
 cd my-app
-cp .env.example .env  # set OPENAI_API_KEY (used for Codex) before running the loop
+codex login  # authenticate via the Codex CLI in your browser (default provider credentials)
+
+# Optional: copy the example env file if you prefer direct API tokens
+cp .env.example .env
 
 # Prepare a virtual environment and install the scaffolded dev dependencies
 make venv
@@ -118,10 +121,12 @@ douglas run --config path/to/douglas.yaml
 
 ### Configure AI access
 
-Douglas ships with a multi-provider registry. Codex is the default and shares credentials with the OpenAI SDK:
+Douglas ships with a multi-provider registry. The Codex CLI is the default authentication path:
 
-1. Install the OpenAI SDK (`pip install openai`) or use the optional extra (`pip install -e .[openai]`).
-2. Export `OPENAI_API_KEY`. You can also set `OPENAI_MODEL` (or `OPENAI_CODEX_MODEL`) plus `OPENAI_BASE_URL`/`OPENAI_API_BASE` for compatible endpoints.
+1. Install the Codex CLI and run `codex login` to authenticate via your browser. Douglas will reuse the CLI session automatically.
+2. If you prefer to skip the CLI, install the OpenAI SDK (`pip install openai` or `pip install -e .[openai]`) and export `OPENAI_API_KEY`. Optional knobs like `OPENAI_MODEL`, `OPENAI_CODEX_MODEL`, and `OPENAI_BASE_URL`/`OPENAI_API_BASE` remain supported.
+
+You can override the CLI executable path with `CODEX_CLI_PATH` when needed.
 
 Additional providers honour their respective environment variables when available:
 
@@ -302,7 +307,8 @@ This walkthrough shows how to exercise Douglas on a fresh repository without dep
    - Copy `templates/douglas.yaml.tpl` and adapt it to your repo (at minimum set the project name and ensure the `paths.app_src` and `paths.tests` entries match your layout).
 
 4. **Configure the LLM provider**
-   - Export `OPENAI_API_KEY` (and optionally `OPENAI_MODEL` or `OPENAI_BASE_URL`) to enable the bundled OpenAI integration.
+   - Authenticate with the Codex CLI (`codex login`) – this opens a browser flow and stores credentials that Douglas consumes automatically. Set `CODEX_CLI_PATH` if the executable lives outside your `PATH`.
+   - Alternatively, export `OPENAI_API_KEY` (and optionally `OPENAI_MODEL` or `OPENAI_BASE_URL`) to drive the OpenAI transport directly instead of the CLI-managed credentials.
    - For offline experimentation you can monkeypatch `Douglas.create_llm_provider` to return a simple object with a `generate_code(prompt)` method that prints the prompt and returns deterministic output (the test suite demonstrates this pattern). The built-in provider will also fall back to a local stub whenever credentials or the SDK are unavailable.
 
 5. **Run the development loop**

--- a/douglas/providers/codex_provider.py
+++ b/douglas/providers/codex_provider.py
@@ -1,8 +1,11 @@
-"""Codex provider built on top of the OpenAI provider implementation."""
+"""Codex provider that prefers the Codex CLI for authentication."""
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
+import subprocess
 from typing import Optional
 
 from douglas.providers.openai_provider import OpenAIProvider
@@ -12,24 +15,137 @@ class CodexProvider(OpenAIProvider):
     """LLM provider that targets the (legacy) OpenAI Codex models."""
 
     DEFAULT_MODEL = "code-davinci-002"
+    _CLI_EXECUTABLE_ENV = "CODEX_CLI_PATH"
+    _CLI_DEFAULT_EXECUTABLE = "codex"
+    _TOKEN_KEYS = ("token", "access_token", "api_key")
+    _TOKEN_CHARACTERS = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+    )
 
     def __init__(
         self,
         model_name: Optional[str] = None,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        cli_path: Optional[str] = None,
     ) -> None:
+        cli_token = None
+        if api_key is None:
+            resolved_cli_path = self._resolve_cli_path(cli_path)
+            cli_token = self._resolve_cli_token(resolved_cli_path)
+        else:
+            resolved_cli_path = None
+
         resolved_model = (
             model_name
             or os.getenv("OPENAI_CODEX_MODEL")
             or os.getenv("OPENAI_MODEL")
             or self.DEFAULT_MODEL
         )
+
         super().__init__(
             model_name=resolved_model,
-            api_key=api_key,
+            api_key=api_key or cli_token,
             base_url=base_url,
         )
+
+        self._cli_path = resolved_cli_path
+        self._cli_token = cli_token
+
+    def _resolve_cli_path(self, cli_path: Optional[str]) -> Optional[str]:
+        explicit = cli_path or os.getenv(self._CLI_EXECUTABLE_ENV)
+        if isinstance(explicit, str) and explicit.strip():
+            return explicit.strip()
+        return shutil.which(self._CLI_DEFAULT_EXECUTABLE)
+
+    def _resolve_cli_token(self, cli_path: Optional[str]) -> Optional[str]:
+        if not cli_path:
+            return None
+
+        try:
+            result = subprocess.run(
+                [cli_path, "auth", "token"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return None
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
+            message = exc.stderr.strip() or exc.stdout.strip()
+            if message:
+                print(
+                    "Warning: Failed to retrieve Codex token via CLI; "
+                    f"falling back to environment variables. Details: {message}"
+                )
+            return None
+
+        token = self._parse_cli_token(result.stdout, result.stderr)
+        if token:
+            return token
+
+        print(
+            "Warning: Codex CLI returned no token; falling back to environment "
+            "variables."
+        )
+        return None
+
+    @classmethod
+    def _parse_cli_token(cls, stdout: str, stderr: str) -> Optional[str]:
+        for stream in (stdout, stderr):
+            token = cls._parse_token_from_stream(stream)
+            if token:
+                return token
+        return None
+
+    @classmethod
+    def _parse_token_from_stream(cls, stream: str) -> Optional[str]:
+        if not stream:
+            return None
+
+        for raw_line in reversed(stream.splitlines()):
+            token = cls._parse_token_from_line(raw_line)
+            if token:
+                return token
+        return None
+
+    @classmethod
+    def _parse_token_from_line(cls, line: str) -> Optional[str]:
+        stripped = line.strip()
+        if not stripped:
+            return None
+
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                pass
+            else:
+                for key in cls._TOKEN_KEYS:
+                    value = payload.get(key)
+                    if isinstance(value, str):
+                        candidate = value.strip()
+                        if cls._looks_like_token(candidate):
+                            return candidate
+
+        if ":" in stripped:
+            prefix, _, remainder = stripped.partition(":")
+            normalized_prefix = prefix.strip().lower().replace(" ", "_")
+            if normalized_prefix in cls._TOKEN_KEYS:
+                candidate = remainder.strip()
+                if cls._looks_like_token(candidate):
+                    return candidate
+
+        if cls._looks_like_token(stripped):
+            return stripped
+
+        return None
+
+    @classmethod
+    def _looks_like_token(cls, value: str) -> bool:
+        if not value:
+            return False
+        return all(character in cls._TOKEN_CHARACTERS for character in value)
 
     def _fallback(self, prompt: str) -> str:  # pragma: no cover - log output only
         print("[CodexProvider] Falling back to placeholder output. Prompt preview:")

--- a/templates/init/.env.example.tpl
+++ b/templates/init/.env.example.tpl
@@ -1,3 +1,4 @@
-# Environment variables required by Douglas
-# Copy this file to `.env` and update the values before running the loop.
+# Environment variables recognised by Douglas
+# Authentication defaults to the Codex CLI (`codex login`). Populate the values
+# below only if you prefer to provide tokens directly.
 OPENAI_API_KEY=

--- a/templates/init/python/README.md.tpl
+++ b/templates/init/python/README.md.tpl
@@ -4,9 +4,10 @@ This project was bootstrapped with [Douglas](${douglas_readme_url}).
 
 ## Quickstart
 
-1. Copy `.env.example` to `.env` and set `OPENAI_API_KEY`.
-2. Create a virtual environment with `make venv`.
-3. Run the tests with `make test`.
-4. Start iterating with `douglas run` once you're ready.
+1. Run `codex login` to authenticate via your browser (Codex is the default provider).
+2. (Optional) Copy `.env.example` to `.env` if you plan to provide tokens manually.
+3. Create a virtual environment with `make venv`.
+4. Run the tests with `make test`.
+5. Start iterating with `douglas run` once you're ready.
 
 Refer to the Douglas README for detailed documentation and advanced workflows.

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,11 +1,32 @@
 from pathlib import Path
+import sys
 
 import yaml
 from typer.testing import CliRunner
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from douglas import cli as cli_module
 from douglas.cli import app
 from douglas.core import Douglas
+
+
+def test_load_default_init_config_uses_repo_template(monkeypatch):
+    calls = []
+
+    def _record_secho(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(cli_module.typer, "secho", _record_secho)
+
+    config = cli_module._load_default_init_config()
+
+    developer_cadence = (
+        config.get("cadence", {}).get("Developer", {}).get("development")
+    )
+
+    assert developer_cadence == "daily"
+    assert calls == []
 
 
 def test_cli_init_without_config(monkeypatch, tmp_path):

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -1,0 +1,47 @@
+import types
+
+import pytest
+
+from douglas.providers import codex_provider
+from douglas.providers.codex_provider import CodexProvider
+
+
+class _DummyResult:
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_codex_provider_prefers_cli_token(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    monkeypatch.setattr(
+        codex_provider.shutil, "which", lambda executable: "/usr/bin/codex"
+    )
+
+    fake_subprocess = types.SimpleNamespace(
+        run=lambda *args, **kwargs: _DummyResult(stdout="token-from-cli\n")
+    )
+    monkeypatch.setattr(codex_provider, "subprocess", fake_subprocess)
+
+    provider = CodexProvider()
+
+    assert provider._cli_token == "token-from-cli"
+    assert provider._api_key == "token-from-cli"
+
+
+@pytest.mark.parametrize(
+    "stdout, stderr, expected",
+    [
+        ("token-value\n", "", "token-value"),
+        ("Access token: another-token\n", "", "another-token"),
+        ("{\"token\": \"json-token\"}\n", "", "json-token"),
+        ("", "{\"access_token\": \"stderr-token\"}", "stderr-token"),
+    ],
+)
+def test_parse_cli_token(stdout: str, stderr: str, expected: str) -> None:
+    assert CodexProvider._parse_cli_token(stdout, stderr) == expected
+
+
+def test_parse_cli_token_rejects_noise() -> None:
+    assert CodexProvider._parse_cli_token("Please login", "") is None


### PR DESCRIPTION
## Summary
- prefer Codex CLI credentials when initialising the Codex provider and fall back to environment variables only when necessary
- document Codex CLI authentication in the main README and scaffolding templates, including guidance on overriding the executable path
- add regression tests covering Codex CLI token parsing and CLI preference

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3e8a944588326abb80574202dd231