### PR TITLE
feat: add parallel agents, logging, dashboard, and demos

### DIFF
--- a/.douglas/demos/example_demo.yaml
+++ b/.douglas/demos/example_demo.yaml
@@ -1,0 +1,18 @@
+name: sample-demo
+sandbox:
+  command: ["python", "-m", "http.server", "8001"]
+  env:
+    PYTHONUNBUFFERED: "1"
+steps:
+  - name: Show project tree
+    type: cli
+    command: ["ls", "-1"]
+  - name: Fetch root endpoint
+    type: api
+    request:
+      method: GET
+      url: "http://127.0.0.1:8001"
+      timeout: 2
+  - name: Placeholder UI walkthrough
+    type: gui
+    script: tests/gui_walkthrough.py

--- a/douglas/agents/__init__.py
+++ b/douglas/agents/__init__.py
@@ -1,0 +1,16 @@
+"""Parallel agent execution helpers for Douglas."""
+
+from __future__ import annotations
+
+from douglas.agents.executor import AgentExecutionResult, ParallelAgentExecutor
+from douglas.agents.locks import FileLockManager
+from douglas.agents.merger import MergerAgent
+from douglas.agents.workspace import AgentWorkspace
+
+__all__ = [
+    "AgentExecutionResult",
+    "AgentWorkspace",
+    "FileLockManager",
+    "MergerAgent",
+    "ParallelAgentExecutor",
+]

--- a/douglas/agents/executor.py
+++ b/douglas/agents/executor.py
@@ -1,0 +1,93 @@
+"""Parallel agent execution primitives."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
+
+from douglas.agents.locks import FileLockManager
+from douglas.agents.workspace import AgentCommandResult, AgentWorkspace
+from douglas.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class AgentExecutionResult:
+    """Result produced by a background agent execution."""
+
+    agent_id: str
+    workspace: AgentWorkspace
+    command_result: AgentCommandResult
+    metadata: Mapping[str, str] | None = None
+
+
+class ParallelAgentExecutor:
+    """Coordinate parallel execution of CLI agents."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: Path | str | None = None,
+        lock_manager: FileLockManager | None = None,
+        max_workers: Optional[int] = None,
+    ) -> None:
+        base = Path(workspace_root or ".douglas/workspaces")
+        base.mkdir(parents=True, exist_ok=True)
+        self.workspace_root = base
+        self.lock_manager = lock_manager or FileLockManager(base.parent / "locks")
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        self._workspaces: dict[str, AgentWorkspace] = {}
+
+    def _workspace_for(self, agent_id: str) -> AgentWorkspace:
+        if agent_id not in self._workspaces:
+            workspace = AgentWorkspace(agent_id, self.workspace_root / agent_id, self.lock_manager)
+            self._workspaces[agent_id] = workspace
+        return self._workspaces[agent_id]
+
+    def submit(
+        self,
+        command: Iterable[str],
+        *,
+        agent_id: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        timeout: Optional[float] = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> concurrent.futures.Future[AgentExecutionResult]:
+        """Schedule an agent command for execution."""
+
+        resolved_agent_id = agent_id or uuid.uuid4().hex
+        workspace = self._workspace_for(resolved_agent_id)
+        logger.debug(
+            "Scheduling agent %s command %s",
+            resolved_agent_id,
+            list(command),
+            extra={"metadata": {"agent": resolved_agent_id}},
+        )
+
+        def runner() -> AgentExecutionResult:
+            command_result = workspace.run_command(command, env=env, timeout=timeout)
+            return AgentExecutionResult(
+                agent_id=resolved_agent_id,
+                workspace=workspace,
+                command_result=command_result,
+                metadata=metadata,
+            )
+
+        return self._executor.submit(runner)
+
+    def shutdown(self, wait: bool = True) -> None:
+        logger.debug("Shutting down ParallelAgentExecutor")
+        self._executor.shutdown(wait=wait)
+
+    def get_workspace(self, agent_id: str) -> AgentWorkspace:
+        """Return the workspace for a particular agent."""
+
+        return self._workspace_for(agent_id)
+
+
+__all__ = ["AgentExecutionResult", "ParallelAgentExecutor"]

--- a/douglas/agents/locks.py
+++ b/douglas/agents/locks.py
@@ -76,7 +76,10 @@ class FileLockManager:
                 while True:
                     try:
                         fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                        os.close(fd)
+                        try:
+                            os.close(fd)
+                        finally:
+                            pass
                         acquired.append(lock_path)
                         break
                     except FileExistsError:

--- a/douglas/agents/locks.py
+++ b/douglas/agents/locks.py
@@ -1,0 +1,108 @@
+"""File lock coordination utilities for Douglas agents."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+from douglas.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class FileLockAcquisitionError(RuntimeError):
+    """Raised when Douglas cannot obtain a lock within the timeout."""
+
+
+@dataclass(frozen=True)
+class LockHandle:
+    """Represents an acquired set of locks."""
+
+    paths: tuple[Path, ...]
+
+
+class FileLockManager:
+    """Manage lockfiles so agents coordinate access to shared resources."""
+
+    def __init__(
+        self,
+        lock_root: Path | str,
+        *,
+        default_timeout: float = 30.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        self.lock_root = Path(lock_root)
+        self.lock_root.mkdir(parents=True, exist_ok=True)
+        self.default_timeout = float(default_timeout)
+        self.poll_interval = float(poll_interval)
+
+    def _lock_path(self, target: Path) -> Path:
+        digest = hashlib.sha256(str(target.resolve()).encode("utf-8")).hexdigest()
+        return self.lock_root / f"{digest}.lock"
+
+    @contextmanager
+    def acquire(
+        self,
+        paths: Iterable[Path | str],
+        *,
+        timeout: float | None = None,
+    ) -> Iterator[LockHandle]:
+        """Acquire locks for the provided paths, yielding once held."""
+
+        resolved: Sequence[Path] = tuple(sorted(Path(p).resolve() for p in paths))
+        if not resolved:
+            yield LockHandle(())
+            return
+
+        timeout = self.default_timeout if timeout is None else float(timeout)
+        start = time.monotonic()
+        acquired: list[Path] = []
+
+        try:
+            for target in resolved:
+                lock_path = self._lock_path(target)
+                remaining = timeout - (time.monotonic() - start)
+                if remaining <= 0:
+                    raise FileLockAcquisitionError(
+                        f"Timed out acquiring lock for {target} after {timeout:.1f}s",
+                    )
+                deadline = time.monotonic() + remaining
+                while True:
+                    try:
+                        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                        os.close(fd)
+                        acquired.append(lock_path)
+                        break
+                    except FileExistsError:
+                        if time.monotonic() >= deadline:
+                            raise FileLockAcquisitionError(
+                                f"Timed out acquiring lock for {target} after {timeout:.1f}s",
+                            )
+                        time.sleep(self.poll_interval)
+                logger.debug(
+                    "Acquired lock for %s",
+                    target,
+                    extra={"metadata": {"lock": str(target)}},
+                )
+            yield LockHandle(tuple(resolved))
+        finally:
+            for lock_path in reversed(acquired):
+                try:
+                    os.unlink(lock_path)
+                except FileNotFoundError:
+                    pass
+            if acquired:
+                logger.debug(
+                    "Released locks for %s",
+                    ", ".join(str(p) for p in resolved),
+                    extra={"metadata": {"locks": [str(p) for p in resolved]}},
+                )
+
+
+__all__ = ["FileLockAcquisitionError", "FileLockManager", "LockHandle"]

--- a/douglas/agents/merger.py
+++ b/douglas/agents/merger.py
@@ -1,0 +1,62 @@
+"""Merger agent that consolidates workspace outputs into the main repo."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from douglas.agents.executor import ParallelAgentExecutor
+from douglas.logging import get_logger, log_action
+
+
+logger = get_logger(__name__)
+
+
+class MergerAgent:
+    """Apply agent workspace changes back into the repository."""
+
+    def __init__(
+        self,
+        executor: ParallelAgentExecutor,
+        *,
+        target_root: Path | str | None = None,
+    ) -> None:
+        self.executor = executor
+        self.target_root = Path(target_root or Path.cwd())
+        self.target_root.mkdir(parents=True, exist_ok=True)
+
+    @log_action("merge-workspace", logger_factory=lambda: logger)
+    def merge(self, agent_id: str, *, clean: bool = False) -> list[Path]:
+        """Merge the ``changes`` directory from an agent workspace into the repo."""
+
+        workspace = self.executor.get_workspace(agent_id)
+        changes_dir = workspace.changes_dir
+        if not changes_dir.exists():
+            logger.warning("No changes directory found for agent %s", agent_id)
+            return []
+
+        applied_files: list[Path] = []
+        for path in sorted(changes_dir.rglob("*")):
+            if path.is_dir():
+                continue
+            relative = path.relative_to(changes_dir)
+            destination = self.target_root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with self.executor.lock_manager.acquire([destination]):
+                shutil.copy2(path, destination)
+            applied_files.append(destination)
+            logger.debug(
+                "Merged %s from agent %s",
+                relative,
+                agent_id,
+                extra={"metadata": {"agent": agent_id, "file": str(relative)}},
+            )
+
+        if clean:
+            shutil.rmtree(changes_dir)
+            changes_dir.mkdir()
+
+        return applied_files
+
+
+__all__ = ["MergerAgent"]

--- a/douglas/agents/workspace.py
+++ b/douglas/agents/workspace.py
@@ -1,0 +1,117 @@
+"""Agent workspace helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+from douglas.agents.locks import FileLockManager
+from douglas.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class AgentCommandResult:
+    """Represents the result of a command executed inside an agent workspace."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    duration: float
+    command: list[str]
+
+
+@dataclass
+class AgentWorkspace:
+    """Isolated filesystem workspace for an agent."""
+
+    agent_id: str
+    root: Path
+    lock_manager: FileLockManager
+    metadata_path: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "changes").mkdir(exist_ok=True)
+        (self.root / "artifacts").mkdir(exist_ok=True)
+        self.metadata_path = self.root / "metadata.json"
+        if not self.metadata_path.exists():
+            self.metadata_path.write_text(json.dumps({"agent_id": self.agent_id}, indent=2))
+
+    @property
+    def changes_dir(self) -> Path:
+        return self.root / "changes"
+
+    @property
+    def artifacts_dir(self) -> Path:
+        return self.root / "artifacts"
+
+    def run_command(
+        self,
+        command: Iterable[str],
+        *,
+        env: Optional[dict[str, str]] = None,
+        timeout: Optional[float] = None,
+    ) -> AgentCommandResult:
+        """Execute a command within the workspace."""
+
+        command_list = list(command)
+        environment = os.environ.copy()
+        if env:
+            environment.update(env)
+        start = time.perf_counter()
+        process = subprocess.run(
+            command_list,
+            cwd=self.root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        duration = time.perf_counter() - start
+        logger.debug(
+            "Agent %s executed %s in %.2fs (rc=%s)",
+            self.agent_id,
+            command_list,
+            duration,
+            process.returncode,
+            extra={"metadata": {"agent": self.agent_id, "duration": duration}},
+        )
+        return AgentCommandResult(
+            returncode=process.returncode,
+            stdout=process.stdout,
+            stderr=process.stderr,
+            duration=duration,
+            command=command_list,
+        )
+
+    def record_change(self, relative_path: Path | str, content: str) -> None:
+        target = (self.changes_dir / Path(relative_path)).resolve()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+    def copy_into_changes(self, source: Path, relative_dest: Path | str | None = None) -> None:
+        destination = self.changes_dir / (relative_dest or source.name)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.copytree(source, destination)
+        else:
+            shutil.copy2(source, destination)
+
+    def lock_files(self, *paths: Path | str, timeout: Optional[float] = None):
+        absolute_paths = [self.changes_dir / Path(p) for p in paths]
+        return self.lock_manager.acquire(absolute_paths, timeout=timeout)
+
+
+__all__ = ["AgentWorkspace", "AgentCommandResult"]

--- a/douglas/dashboard/data.py
+++ b/douglas/dashboard/data.py
@@ -1,0 +1,186 @@
+"""Utilities for loading Douglas run-state into dashboard-friendly structures."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import yaml
+
+_STATUS_BUCKETS = [
+    "not_started",
+    "in_progress",
+    "blocked",
+    "in_test",
+    "finished",
+]
+
+
+@dataclass
+class WorkSummary:
+    """Aggregated counts of items by status."""
+
+    counts: dict[str, dict[str, int]] = field(default_factory=dict)
+
+
+@dataclass
+class BurndownPoint:
+    """Point in a burn-up/down chart."""
+
+    date: datetime
+    remaining: int
+    completed: int
+
+
+@dataclass
+class DashboardData:
+    """Container of data exposed via the dashboard API."""
+
+    summary: WorkSummary
+    burndown: list[BurndownPoint]
+    inbox: dict[str, int]
+    cumulative_flow: dict[str, list[tuple[str, int]]]
+
+
+def _safe_load(path: Path) -> Mapping[str, Any] | list[Mapping[str, Any]] | None:
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.strip():
+        return None
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+
+def _count_statuses(entries: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    buckets = {status: 0 for status in _STATUS_BUCKETS}
+    for entry in entries:
+        status = str(entry.get("status", "not_started")).strip().lower()
+        buckets.setdefault(status, 0)
+        buckets[status] += 1
+    return buckets
+
+
+def load_work_summary(base_path: Path) -> WorkSummary:
+    summary: dict[str, dict[str, int]] = {}
+    for category in ("epics", "features", "work-items", "stories"):
+        directory = base_path / category
+        if not directory.exists():
+            continue
+        entries: list[Mapping[str, Any]] = []
+        for pattern in ("*.yml", "*.yaml", "*.json"):
+            for file_path in directory.rglob(pattern):
+                payload = _safe_load(file_path)
+                if isinstance(payload, Mapping):
+                    entries.append(payload)
+        summary[category] = _count_statuses(entries)
+    return WorkSummary(counts=summary)
+
+
+def _resolve_state_root(base_path: Path) -> Path:
+    direct_state = base_path / "state"
+    if direct_state.exists():
+        return base_path
+    nested = base_path / ".douglas"
+    if nested.exists():
+        return nested
+    return base_path
+
+
+def load_burndown(base_path: Path) -> list[BurndownPoint]:
+    state_root = _resolve_state_root(base_path)
+    history_path = state_root / "state" / "sprint_history.json"
+    if not history_path.exists():
+        history_path = state_root / "state" / "burndown.json"
+    payload = _safe_load(history_path)
+    points: list[BurndownPoint] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            if not isinstance(entry, Mapping):
+                continue
+            date_str = str(entry.get("date", "")) or str(entry.get("timestamp", ""))
+            try:
+                date = datetime.fromisoformat(date_str)
+            except ValueError:
+                continue
+            remaining = int(entry.get("remaining", entry.get("todo", 0)))
+            completed = int(entry.get("completed", entry.get("done", 0)))
+            points.append(BurndownPoint(date=date, remaining=remaining, completed=completed))
+    return points
+
+
+def load_inbox_counts(base_path: Path) -> dict[str, int]:
+    inbox_dir = (_resolve_state_root(base_path) / "inbox").resolve()
+    unanswered = 0
+    answered = 0
+    if not inbox_dir.exists():
+        inbox_dir = base_path / "inbox"
+    if not inbox_dir.exists():
+        return {"unanswered": 0, "answered": 0}
+    for pattern in ("*.yaml", "*.yml", "*.json"):
+        for path in inbox_dir.glob(pattern):
+            payload = _safe_load(path)
+            if isinstance(payload, Mapping):
+                if payload.get("answer"):
+                    answered += 1
+                else:
+                    unanswered += 1
+    return {"unanswered": unanswered, "answered": answered}
+
+
+def load_cumulative_flow(base_path: Path) -> dict[str, list[tuple[str, int]]]:
+    state_root = _resolve_state_root(base_path)
+    flow_path = state_root / "state" / "cumulative_flow.json"
+    payload = _safe_load(flow_path)
+    if not isinstance(payload, Mapping):
+        return {}
+    flow: dict[str, list[tuple[str, int]]] = {}
+    for status, datapoints in payload.items():
+        if not isinstance(datapoints, list):
+            continue
+        entries: list[tuple[str, int]] = []
+        for entry in datapoints:
+            if not isinstance(entry, Mapping):
+                continue
+            timestamp = str(entry.get("date", ""))
+            count = int(entry.get("count", 0))
+            entries.append((timestamp, count))
+        flow[status] = entries
+    return flow
+
+
+def load_dashboard_data(base_path: Path | str) -> DashboardData:
+    base = Path(base_path)
+    summary = load_work_summary(base)
+    burndown = load_burndown(base)
+    inbox = load_inbox_counts(base)
+    cumulative_flow = load_cumulative_flow(base)
+    return DashboardData(
+        summary=summary,
+        burndown=burndown,
+        inbox=inbox,
+        cumulative_flow=cumulative_flow,
+    )
+
+
+__all__ = [
+    "BurndownPoint",
+    "DashboardData",
+    "WorkSummary",
+    "load_dashboard_data",
+    "load_work_summary",
+    "load_burndown",
+    "load_inbox_counts",
+    "load_cumulative_flow",
+]

--- a/douglas/dashboard/data.py
+++ b/douglas/dashboard/data.py
@@ -155,7 +155,7 @@ def load_cumulative_flow(base_path: Path) -> dict[str, list[tuple[str, int]]]:
                 continue
             timestamp = str(entry.get("date", ""))
             count = int(entry.get("count", 0))
-            entries.append((timestamp, count))
+            entries.append([timestamp, count])
         flow[status] = entries
     return flow
 

--- a/douglas/dashboard/server.py
+++ b/douglas/dashboard/server.py
@@ -1,0 +1,149 @@
+"""Dashboard exposing Douglas progress state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - fallback when FastAPI is not installed
+    from fastapi import FastAPI, HTTPException
+    from fastapi.responses import HTMLResponse
+except Exception:  # pragma: no cover - fallback branch
+    FastAPI = None  # type: ignore[assignment]
+    HTMLResponse = None  # type: ignore[assignment]
+
+    class HTTPException(Exception):  # type: ignore[no-redef]
+        def __init__(self, status_code: int, detail: str) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+from douglas.dashboard.data import DashboardData, load_dashboard_data
+from douglas.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def create_app(state_root: Path | str = Path(".")) -> FastAPI:
+    """Create a FastAPI app serving Douglas dashboard data."""
+
+    root_path = Path(state_root)
+    if FastAPI is None:  # pragma: no cover - fallback without FastAPI installed
+        return _FallbackDashboard(root_path)  # type: ignore[return-value]
+    app = FastAPI(title="Douglas Dashboard", version="1.0.0")
+
+    @app.get("/healthz")
+    def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/api/summary")
+    def api_summary() -> dict[str, Any]:
+        data = _load(root_path)
+        return {
+            "counts": data.summary.counts,
+            "inbox": data.inbox,
+        }
+
+    @app.get("/api/burndown")
+    def api_burndown() -> list[dict[str, Any]]:
+        data = _load(root_path)
+        return [
+            {
+                "date": point.date.isoformat(),
+                "remaining": point.remaining,
+                "completed": point.completed,
+            }
+            for point in data.burndown
+        ]
+
+    @app.get("/api/cumulative-flow")
+    def api_cumulative_flow() -> dict[str, list[tuple[str, int]]]:
+        data = _load(root_path)
+        return data.cumulative_flow
+
+    @app.get("/")
+    def index() -> HTMLResponse:
+        dashboard_html = _render_template()
+        return HTMLResponse(content=dashboard_html)
+
+    return app
+
+
+def _load(root_path: Path) -> DashboardData:
+    if not root_path.exists():
+        raise HTTPException(status_code=404, detail="State root not found")
+    data = load_dashboard_data(root_path)
+    logger.debug("Loaded dashboard data", extra={"metadata": {"root": str(root_path)}})
+    return data
+
+
+def _render_template() -> str:
+    html_path = Path(__file__).parent / "templates" / "index.html"
+    return html_path.read_text(encoding="utf-8")
+
+
+class _FallbackDashboard:
+    """Simplified dashboard used when FastAPI is not available."""
+
+    def __init__(self, root_path: Path) -> None:
+        self._root_path = root_path
+
+    def healthcheck(self) -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "ok"}
+
+    def api_summary(self) -> dict[str, Any]:
+        data = _load(self._root_path)
+        return {"counts": data.summary.counts, "inbox": data.inbox}
+
+    def api_burndown(self) -> list[dict[str, Any]]:
+        data = _load(self._root_path)
+        return [
+            {
+                "date": point.date.isoformat(),
+                "remaining": point.remaining,
+                "completed": point.completed,
+            }
+            for point in data.burndown
+        ]
+
+    def api_cumulative_flow(self) -> dict[str, list[tuple[str, int]]]:
+        data = _load(self._root_path)
+        return data.cumulative_flow
+
+    def index(self) -> str:
+        return _render_template()
+
+
+def render_static_dashboard(state_root: Path | str, output_dir: Path | str) -> Path:
+    """Render the dashboard summary to a standalone HTML file."""
+
+    data = load_dashboard_data(state_root)
+    output_directory = Path(output_dir)
+    output_directory.mkdir(parents=True, exist_ok=True)
+    template = _render_template()
+    hydrated = template.replace("__DASHBOARD_PAYLOAD__", json.dumps(_to_payload(data)))
+    target = output_directory / "index.html"
+    target.write_text(hydrated, encoding="utf-8")
+    logger.info("Static dashboard written to %s", target)
+    return target
+
+
+def _to_payload(data: DashboardData) -> dict[str, Any]:
+    return {
+        "counts": data.summary.counts,
+        "inbox": data.inbox,
+        "burndown": [
+            {
+                "date": point.date.isoformat(),
+                "remaining": point.remaining,
+                "completed": point.completed,
+            }
+            for point in data.burndown
+        ],
+        "cumulative_flow": data.cumulative_flow,
+    }
+
+
+__all__ = ["create_app", "render_static_dashboard"]

--- a/douglas/dashboard/templates/index.html
+++ b/douglas/dashboard/templates/index.html
@@ -65,7 +65,7 @@
         }
         let html = '<table><thead><tr><th>Status</th><th>History</th></tr></thead><tbody>';
         statuses.forEach((status) => {
-          const trail = flow[status].map(([date, count]) => `${new Date(date).toLocaleDateString()}: ${count}`).join('<br/>');
+          const trail = flow[status].map(({date, count}) => `${new Date(date).toLocaleDateString()}: ${count}`).join('<br/>');
           html += `<tr><td>${status}</td><td>${trail}</td></tr>`;
         });
         html += '</tbody></table>';

--- a/douglas/dashboard/templates/index.html
+++ b/douglas/dashboard/templates/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Douglas Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="15" />
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; background: #0b1725; color: #f2f6fc; }
+      header { padding: 1.5rem; background: #11263f; }
+      main { padding: 1.5rem; }
+      h1 { margin: 0; font-size: 1.8rem; }
+      section { margin-bottom: 2rem; }
+      table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
+      th, td { padding: 0.5rem; border-bottom: 1px solid rgba(255,255,255,0.1); text-align: left; }
+      .card { background: #152c4d; padding: 1rem; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.2); }
+      .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+      canvas { background: #f2f6fc; border-radius: 8px; padding: 1rem; }
+      small { color: rgba(255, 255, 255, 0.6); }
+    </style>
+    <script>
+      const staticPayload = '__DASHBOARD_PAYLOAD__';
+      async function fetchData() {
+        if (staticPayload && !staticPayload.startsWith('__')) {
+          return JSON.parse(staticPayload);
+        }
+        const [summary, burndown, flow] = await Promise.all([
+          fetch('/api/summary').then((r) => r.json()),
+          fetch('/api/burndown').then((r) => r.json()),
+          fetch('/api/cumulative-flow').then((r) => r.json()),
+        ]);
+        return { counts: summary.counts, inbox: summary.inbox, burndown, cumulative_flow: flow };
+      }
+
+      function renderTable(container, counts) {
+        const headers = ['Status', 'Epics', 'Features', 'Work items'];
+        const statuses = ['not_started', 'in_progress', 'blocked', 'in_test', 'finished'];
+        let html = '<table><thead><tr>' + headers.map((h) => `<th>${h}</th>`).join('') + '</tr></thead><tbody>';
+        statuses.forEach((status) => {
+          html += '<tr><td>' + status.replace('_', ' ') + '</td>' +
+            ['epics','features','work-items'].map((bucket) => counts[bucket]?.[status] ?? 0).map((value) => `<td>${value}</td>`).join('') + '</tr>';
+        });
+        html += '</tbody></table>';
+        container.innerHTML = html;
+      }
+
+      function renderBurndown(container, points) {
+        if (!points.length) {
+          container.innerHTML = '<small>No burndown data available.</small>';
+          return;
+        }
+        let html = '<table><thead><tr><th>Date</th><th>Remaining</th><th>Completed</th></tr></thead><tbody>';
+        points.forEach((p) => {
+          html += `<tr><td>${new Date(p.date).toLocaleString()}</td><td>${p.remaining}</td><td>${p.completed}</td></tr>`;
+        });
+        html += '</tbody></table>';
+        container.innerHTML = html;
+      }
+
+      function renderFlow(container, flow) {
+        const statuses = Object.keys(flow);
+        if (!statuses.length) {
+          container.innerHTML = '<small>No cumulative flow data available.</small>';
+          return;
+        }
+        let html = '<table><thead><tr><th>Status</th><th>History</th></tr></thead><tbody>';
+        statuses.forEach((status) => {
+          const trail = flow[status].map(([date, count]) => `${new Date(date).toLocaleDateString()}: ${count}`).join('<br/>');
+          html += `<tr><td>${status}</td><td>${trail}</td></tr>`;
+        });
+        html += '</tbody></table>';
+        container.innerHTML = html;
+      }
+
+      function renderInbox(container, inbox) {
+        container.innerHTML = `<div class="card"><h3>Inbox</h3><p>Unanswered: <strong>${inbox.unanswered ?? 0}</strong><br/>Answered: <strong>${inbox.answered ?? 0}</strong></p></div>`;
+      }
+
+      async function init() {
+        const data = await fetchData();
+        renderTable(document.getElementById('summary'), data.counts || {});
+        renderBurndown(document.getElementById('burndown'), data.burndown || []);
+        renderFlow(document.getElementById('flow'), data.cumulative_flow || {});
+        renderInbox(document.getElementById('inbox'), data.inbox || {});
+      }
+
+      document.addEventListener('DOMContentLoaded', init);
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>Douglas Live Dashboard</h1>
+      <small>Auto-refreshes every 15 seconds. Aggregates sprint progress, inbox activity, and flow metrics.</small>
+    </header>
+    <main>
+      <section class="card">
+        <h2>Backlog summary</h2>
+        <div id="summary"></div>
+      </section>
+      <div class="grid">
+        <section class="card">
+          <h2>Sprint burn-up/down</h2>
+          <div id="burndown"></div>
+        </section>
+        <section class="card" id="inbox"></section>
+      </div>
+      <section class="card">
+        <h2>Cumulative flow</h2>
+        <div id="flow"></div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/douglas/demo/__init__.py
+++ b/douglas/demo/__init__.py
@@ -1,0 +1,7 @@
+"""Demo runner DSL for Douglas."""
+
+from __future__ import annotations
+
+from douglas.demo.runner import DemoReport, DemoRunner
+
+__all__ = ["DemoReport", "DemoRunner"]

--- a/douglas/demo/runner.py
+++ b/douglas/demo/runner.py
@@ -1,0 +1,275 @@
+"""Demo script execution engine."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from douglas.logging import get_logger, log_action
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class DemoStepResult:
+    """Outcome of executing a single demo step."""
+
+    name: str
+    step_type: str
+    status: str
+    stdout: str = ""
+    stderr: str = ""
+    duration: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DemoReport:
+    """Aggregate demo execution report."""
+
+    name: str
+    steps: list[DemoStepResult]
+    started_at: float
+    finished_at: float
+    artifacts_dir: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "duration": self.finished_at - self.started_at,
+            "steps": [
+                {
+                    "name": step.name,
+                    "type": step.step_type,
+                    "status": step.status,
+                    "stdout": step.stdout,
+                    "stderr": step.stderr,
+                    "duration": step.duration,
+                    "metadata": step.metadata,
+                }
+                for step in self.steps
+            ],
+        }
+
+
+class DemoRunner:
+    """Run Douglas demo scripts defined via YAML or JSON DSL."""
+
+    def __init__(self, *, workspace: Path | str | None = None) -> None:
+        self.workspace = Path(workspace or ".douglas/demos")
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        (self.workspace / "reports").mkdir(exist_ok=True)
+
+    @log_action("demo-run", logger_factory=lambda: logger)
+    def run(self, script_path: Path | str, *, output_dir: Path | str | None = None) -> DemoReport:
+        script = self._load_script(Path(script_path))
+        report_dir = Path(output_dir or (self.workspace / "reports" / script["name"]))
+        report_dir.mkdir(parents=True, exist_ok=True)
+        started = time.perf_counter()
+        results: list[DemoStepResult] = []
+
+        sandbox_process: Optional[subprocess.Popen[str]] = None
+        try:
+            sandbox_config = script.get("sandbox")
+            if sandbox_config:
+                sandbox_process = self._launch_sandbox(sandbox_config, cwd=report_dir)
+
+            for step in script.get("steps", []):
+                result = self._execute_step(step, cwd=report_dir)
+                results.append(result)
+        finally:
+            if sandbox_process is not None:
+                sandbox_process.terminate()
+                try:
+                    sandbox_process.wait(timeout=5)
+                except Exception:
+                    sandbox_process.kill()
+
+        finished = time.perf_counter()
+        report = DemoReport(
+            name=script["name"],
+            steps=results,
+            started_at=started,
+            finished_at=finished,
+            artifacts_dir=report_dir,
+        )
+        self._write_report(report)
+        return report
+
+    def _load_script(self, path: Path) -> dict[str, Any]:
+        if not path.exists():
+            raise FileNotFoundError(path)
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("Demo script must be a mapping")
+        payload.setdefault("name", path.stem)
+        payload.setdefault("steps", [])
+        return payload
+
+    def _launch_sandbox(self, config: dict[str, Any], *, cwd: Path) -> subprocess.Popen[str]:
+        command = config.get("command")
+        if not command:
+            raise ValueError("Sandbox configuration requires a command")
+        env = os.environ.copy()
+        env.update(config.get("env", {}))
+        logger.info("Launching sandbox command: %s", command)
+        return subprocess.Popen(
+            command if isinstance(command, list) else ["/bin/sh", "-c", str(command)],
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def _execute_step(self, step: dict[str, Any], *, cwd: Path) -> DemoStepResult:
+        step_type = step.get("type", "cli")
+        name = step.get("name", step_type)
+        started = time.perf_counter()
+        try:
+            if step_type == "cli":
+                result = self._run_cli_step(step, cwd=cwd)
+            elif step_type == "api":
+                result = self._run_api_step(step)
+            elif step_type == "gui":
+                result = self._run_gui_step(step)
+            else:
+                raise ValueError(f"Unknown demo step type: {step_type}")
+            status = "ok" if result["returncode"] == 0 else "failed"
+            metadata = {k: v for k, v in result.items() if k not in {"stdout", "stderr", "returncode"}}
+            return DemoStepResult(
+                name=name,
+                step_type=step_type,
+                status=status,
+                stdout=result.get("stdout", ""),
+                stderr=result.get("stderr", ""),
+                duration=time.perf_counter() - started,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            logger.exception("Demo step %s failed", name)
+            return DemoStepResult(
+                name=name,
+                step_type=step_type,
+                status="error",
+                stderr=str(exc),
+                duration=time.perf_counter() - started,
+            )
+
+    def _run_cli_step(self, step: dict[str, Any], *, cwd: Path) -> dict[str, Any]:
+        command = step.get("command")
+        if not command:
+            raise ValueError("CLI step requires a command")
+        timeout = step.get("timeout")
+        process = subprocess.run(
+            command if isinstance(command, list) else ["/bin/sh", "-c", str(command)],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return {
+            "stdout": process.stdout,
+            "stderr": process.stderr,
+            "returncode": process.returncode,
+        }
+
+    def _run_api_step(self, step: dict[str, Any]) -> dict[str, Any]:
+        request = step.get("request") or {}
+        url = request.get("url")
+        if not url:
+            raise ValueError("API step requires request.url")
+        method = request.get("method", "GET").upper()
+        data = request.get("json")
+        headers = request.get("headers", {})
+        req = urllib.request.Request(url, method=method)
+        for key, value in headers.items():
+            req.add_header(key, value)
+        body = None
+        if data is not None:
+            body = json.dumps(data).encode("utf-8")
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, data=body, timeout=request.get("timeout", 30)) as response:
+                payload = response.read().decode("utf-8")
+                return {
+                    "stdout": payload,
+                    "stderr": "",
+                    "returncode": 0,
+                    "status": response.status,
+                }
+        except Exception as exc:
+            return {
+                "stdout": "",
+                "stderr": str(exc),
+                "returncode": 1,
+            }
+
+    def _run_gui_step(self, step: dict[str, Any]) -> dict[str, Any]:
+        note = (
+            "GUI steps are not yet implemented. Provide a Playwright script path in `script` "
+            "to prepare for future support."
+        )
+        return {
+            "stdout": note,
+            "stderr": "",
+            "returncode": 0,
+            "pending": step.get("script"),
+        }
+
+    def _write_report(self, report: DemoReport) -> Path:
+        target = report.artifacts_dir / "report.json"
+        target.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+        html_path = report.artifacts_dir / "report.html"
+        html_path.write_text(_render_html_report(report), encoding="utf-8")
+        logger.info("Demo report written to %s", html_path)
+        return target
+
+
+def _render_html_report(report: DemoReport) -> str:
+    rows = []
+    for step in report.steps:
+        rows.append(
+            "<tr>"
+            f"<td>{step.name}</td>"
+            f"<td>{step.step_type}</td>"
+            f"<td>{step.status}</td>"
+            f"<td><pre>{_escape(step.stdout)}</pre></td>"
+            f"<td><pre>{_escape(step.stderr)}</pre></td>"
+            f"<td>{step.duration:.2f}s</td>"
+            "</tr>"
+        )
+    return (
+        "<html><head><meta charset='utf-8'><title>Douglas Demo Report</title>"
+        "<style>body{font-family:Arial,sans-serif;background:#f4f6fb;padding:20px;}"
+        "table{width:100%;border-collapse:collapse;}th,td{border:1px solid #ccc;padding:8px;}"
+        "pre{white-space:pre-wrap;word-break:break-word;background:#1e1e2f;color:#f6f8ff;padding:8px;border-radius:4px;}"
+        "</style></head><body>"
+        f"<h1>Demo report: {report.name}</h1>"
+        f"<p>Duration: {report.finished_at - report.started_at:.2f}s</p>"
+        "<table><thead><tr><th>Name</th><th>Type</th><th>Status</th><th>Stdout</th><th>Stderr</th><th>Duration</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table></body></html>"
+    )
+
+
+def _escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+    )
+
+
+__all__ = ["DemoRunner", "DemoReport", "DemoStepResult"]

--- a/douglas/logging/__init__.py
+++ b/douglas/logging/__init__.py
@@ -1,0 +1,290 @@
+"""Structured logging helpers for Douglas components."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping
+from contextlib import ContextDecorator
+from dataclasses import dataclass
+from logging import Handler, LogRecord
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Optional
+
+_DEFAULT_MAX_BYTES = 10 * 1024 * 1024  # 10MB
+_DEFAULT_BACKUP_COUNT = 5
+_LOGGER_NAME = "douglas"
+_LOCK = threading.RLock()
+_CONFIGURED = False
+_FILE_HANDLER: Optional[Handler] = None
+
+_LEVEL_COLORS = {
+    "DEBUG": "\033[36m",  # cyan
+    "INFO": "\033[32m",  # green
+    "WARNING": "\033[33m",  # yellow
+    "ERROR": "\033[31m",  # red
+    "CRITICAL": "\033[41m",  # red background
+}
+_RESET_COLOR = "\033[0m"
+
+
+class DouglasJsonFormatter(logging.Formatter):
+    """Custom JSON formatter with Douglas metadata."""
+
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
+
+    def format(self, record: LogRecord) -> str:  # noqa: D401
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.default_time_format),
+            "level": record.levelname,
+            "component": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        metadata = {}
+        if hasattr(record, "metadata") and isinstance(record.metadata, Mapping):
+            metadata.update(record.metadata)
+        if "extra" in record.__dict__:
+            extra = record.__dict__["extra"]
+            if isinstance(extra, Mapping) and "metadata" in extra:
+                metadata.update(extra["metadata"])
+        if metadata:
+            payload["metadata"] = metadata
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+class DouglasConsoleFormatter(logging.Formatter):
+    """Human-friendly console formatter with colour support."""
+
+    default_time_format = "%H:%M:%S"
+
+    def format(self, record: LogRecord) -> str:  # noqa: D401 - inherited docs
+        record.__dict__.setdefault("component", record.name)
+        base = super().format(record)
+        level = record.levelname
+        colour = _LEVEL_COLORS.get(level)
+        if not colour or not sys.stdout.isatty():
+            return base
+        return f"{colour}{base}{_RESET_COLOR}"
+
+
+def _coerce_level(value: Optional[str]) -> int:
+    if not value:
+        return logging.INFO
+    if isinstance(value, str):
+        value = value.strip()
+        if value.isdigit():
+            return int(value)
+        mapped = getattr(logging, value.upper(), None)
+        if isinstance(mapped, int):
+            return mapped
+    if isinstance(value, int):
+        return value
+    return logging.INFO
+
+
+def _create_log_directory() -> Path:
+    log_dir = Path(os.getenv("DOUGLAS_LOG_DIR", "logs"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def configure_logging(
+    level: Optional[str] = None,
+    *,
+    log_file: Optional[Path | str] = None,
+    enable_json: bool = True,
+) -> None:
+    """Initialise Douglas logging infrastructure."""
+
+    global _CONFIGURED, _FILE_HANDLER
+
+    with _LOCK:
+        resolved_level = _coerce_level(level or os.getenv("DOUGLAS_LOG_LEVEL"))
+        logger = logging.getLogger(_LOGGER_NAME)
+
+        if not _CONFIGURED:
+            logger.handlers.clear()
+            logger.setLevel(resolved_level)
+            logger.propagate = False
+
+            console_handler = logging.StreamHandler()
+            console_formatter = DouglasConsoleFormatter(
+                fmt="%(asctime)s %(levelname)s %(component)s %(message)s",
+                datefmt="%H:%M:%S",
+            )
+            console_handler.setFormatter(console_formatter)
+            logger.addHandler(console_handler)
+            _CONFIGURED = True
+        else:
+            logger.setLevel(resolved_level)
+
+        if log_file:
+            target_file = Path(log_file)
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            target_file = _create_log_directory() / "douglas.log"
+
+        if _FILE_HANDLER and getattr(_FILE_HANDLER, "baseFilename", None) == str(target_file):
+            return
+
+        if _FILE_HANDLER is not None:
+            logger.removeHandler(_FILE_HANDLER)
+            try:
+                _FILE_HANDLER.close()
+            finally:
+                _FILE_HANDLER = None
+
+        rotation_handler = RotatingFileHandler(
+            target_file,
+            maxBytes=_DEFAULT_MAX_BYTES,
+            backupCount=_DEFAULT_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+
+        if enable_json:
+            formatter: logging.Formatter = DouglasJsonFormatter()
+        else:
+            formatter = logging.Formatter(
+                fmt="%(asctime)s %(levelname)s %(component)s %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+
+        rotation_handler.setFormatter(formatter)
+        logger.addHandler(rotation_handler)
+        _FILE_HANDLER = rotation_handler
+
+
+def get_logger(name: str, *, metadata: Optional[Mapping[str, Any]] = None) -> logging.Logger:
+    """Return a logger scoped under the Douglas namespace."""
+
+    configure_logging()
+    qualified = name if name.startswith(f"{_LOGGER_NAME}.") else f"{_LOGGER_NAME}.{name}"
+    logger = logging.getLogger(qualified)
+    if metadata:
+        return DouglasLoggerAdapter(logger, dict(metadata))
+    return logger
+
+
+class DouglasLoggerAdapter(logging.LoggerAdapter):
+    """Logger adapter that injects metadata for structured logging."""
+
+    def process(self, msg: str, kwargs: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+        extra = dict(kwargs.get("extra", {}))
+        metadata = dict(self.extra)
+        if "metadata" in kwargs:
+            metadata.update(kwargs["metadata"])  # type: ignore[arg-type]
+        if metadata:
+            extra["metadata"] = metadata
+        kwargs["extra"] = extra
+        return msg, dict(kwargs)
+
+
+class log_exceptions(ContextDecorator):
+    """Context manager/decorator that logs uncaught exceptions."""
+
+    def __init__(self, logger: logging.Logger, *, message: str = "Unhandled error") -> None:
+        self.logger = logger
+        self.message = message
+
+    def __enter__(self) -> "log_exceptions":  # noqa: D401 - context protocol
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> bool:
+        if exc_type is not None:
+            self.logger.error(
+                self.message,
+                exc_info=(exc_type, exc_value, exc_traceback),
+            )
+        return False
+
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with self:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+
+def log_action(
+    action: str,
+    *,
+    start_level: int = logging.INFO,
+    success_level: int = logging.INFO,
+    failure_level: int = logging.ERROR,
+    logger_factory: Callable[[], logging.Logger] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator that emits structured entry/exit logs around a callable."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        func_logger = logger_factory() if logger_factory else get_logger(func.__module__)
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start_time = time.perf_counter()
+            func_logger.log(
+                start_level,
+                "%s:start",
+                action,
+                extra={"metadata": {"action": action, "event": "start"}},
+            )
+            try:
+                result = func(*args, **kwargs)
+            except Exception:
+                func_logger.log(
+                    failure_level,
+                    "%s:error",
+                    action,
+                    extra={"metadata": {"action": action, "event": "error"}},
+                    exc_info=True,
+                )
+                raise
+            duration = time.perf_counter() - start_time
+            func_logger.log(
+                success_level,
+                "%s:success",
+                action,
+                extra={"metadata": {"action": action, "event": "success", "duration": duration}},
+            )
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+@dataclass(slots=True)
+class LogRecordBuilder:
+    """Helper for building structured log payloads."""
+
+    logger: logging.Logger
+    level: int = logging.INFO
+    component: Optional[str] = None
+    message: str = ""
+    metadata: dict[str, Any] | None = None
+
+    def emit(self) -> None:
+        payload = self.message
+        extra: dict[str, Any] = {}
+        if self.component:
+            extra.setdefault("component", self.component)
+        if self.metadata:
+            extra.setdefault("metadata", self.metadata)
+        self.logger.log(self.level, payload, extra=extra)
+
+
+__all__ = [
+    "DouglasJsonFormatter",
+    "DouglasConsoleFormatter",
+    "DouglasLoggerAdapter",
+    "LogRecordBuilder",
+    "configure_logging",
+    "get_logger",
+    "log_action",
+    "log_exceptions",
+]

--- a/douglas/logging_utils.py
+++ b/douglas/logging_utils.py
@@ -1,80 +1,25 @@
-"""Logging utilities for Douglas."""
+"""Backward-compatible re-export of Douglas logging helpers."""
 
 from __future__ import annotations
 
-import logging
-import os
-from pathlib import Path
-from typing import Optional
+from douglas.logging import (  # noqa: F401
+    DouglasConsoleFormatter,
+    DouglasJsonFormatter,
+    DouglasLoggerAdapter,
+    LogRecordBuilder,
+    configure_logging,
+    get_logger,
+    log_action,
+    log_exceptions,
+)
 
-_CONFIGURED = False
-_DEFAULT_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
-_DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
-_FILE_HANDLER: Optional[logging.Handler] = None
-_FILE_HANDLER_PATH: Optional[str] = None
-
-
-def configure_logging(level: Optional[str] = None, *, log_file: Optional[str] = None) -> None:
-    """Initialise Douglas logging and optionally attach a persistent log sink."""
-
-    global _CONFIGURED, _FILE_HANDLER, _FILE_HANDLER_PATH
-
-    requested_level = level or os.getenv("DOUGLAS_LOG_LEVEL", "INFO")
-    numeric_level = _as_level(requested_level)
-
-    logger = logging.getLogger("douglas")
-
-    if not _CONFIGURED:
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter(_DEFAULT_FORMAT, _DEFAULT_DATEFMT))
-        logger.addHandler(handler)
-        logger.setLevel(numeric_level)
-        logger.propagate = True
-        _CONFIGURED = True
-    else:
-        logger.setLevel(numeric_level)
-
-    target_path = log_file or os.getenv("DOUGLAS_LOG_FILE")
-    if not target_path:
-        return
-
-    if _FILE_HANDLER_PATH == target_path:
-        # Already logging to the requested file.
-        return
-
-    # Tear down any previous file handler before attaching a new one.
-    if _FILE_HANDLER is not None:
-        logger.removeHandler(_FILE_HANDLER)
-        _FILE_HANDLER.close()
-        _FILE_HANDLER = None
-        _FILE_HANDLER_PATH = None
-
-    file_path = Path(target_path)
-    try:
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.FileHandler(file_path, encoding="utf-8")
-    except OSError:
-        # Silently ignore file handler setup issues; console logging still works.
-        return
-
-    handler.setFormatter(logging.Formatter(_DEFAULT_FORMAT, _DEFAULT_DATEFMT))
-    logger.addHandler(handler)
-    _FILE_HANDLER = handler
-    _FILE_HANDLER_PATH = target_path
-
-
-def get_logger(name: str) -> logging.Logger:
-    """Return a module-specific logger under the Douglas namespace."""
-
-    configure_logging()  # Ensure handlers exist even if user forgot to configure explicitly
-    qualified = name if name.startswith("douglas.") else f"douglas.{name}"
-    return logging.getLogger(qualified)
-
-
-def _as_level(value: str) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        pass
-
-    return getattr(logging, str(value).upper(), logging.INFO)
+__all__ = [
+    "DouglasConsoleFormatter",
+    "DouglasJsonFormatter",
+    "DouglasLoggerAdapter",
+    "LogRecordBuilder",
+    "configure_logging",
+    "get_logger",
+    "log_action",
+    "log_exceptions",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "typer>=0.9",
     "pyyaml>=6.0",
     "rich>=10.11",
+    "fastapi>=0.110",
+    "uvicorn>=0.22",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,8 @@ PROJECT_ROOT_STR = str(PROJECT_ROOT)
 
 if PROJECT_ROOT_STR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_STR)
+
+SRC_ROOT = PROJECT_ROOT / "src"
+SRC_ROOT_STR = str(SRC_ROOT)
+if SRC_ROOT.exists() and SRC_ROOT_STR not in sys.path:
+    sys.path.insert(0, SRC_ROOT_STR)

--- a/tests/test_agent_locking.py
+++ b/tests/test_agent_locking.py
@@ -1,0 +1,51 @@
+import threading
+import time
+
+import pytest
+
+from douglas.agents.locks import FileLockAcquisitionError, FileLockManager
+
+
+def test_lock_manager_blocks_until_release(tmp_path):
+    manager = FileLockManager(tmp_path / "locks", default_timeout=2.0, poll_interval=0.05)
+    target = tmp_path / "shared.txt"
+    target.write_text("data", encoding="utf-8")
+    order: list[str] = []
+
+    def _holder():
+        with manager.acquire([target]):
+            order.append("holder")
+            time.sleep(0.3)
+
+    thread = threading.Thread(target=_holder)
+    thread.start()
+    time.sleep(0.1)
+
+    with manager.acquire([target]):
+        order.append("second")
+
+    thread.join()
+    assert order == ["holder", "second"]
+
+
+def test_lock_manager_times_out(tmp_path):
+    manager = FileLockManager(tmp_path / "locks", default_timeout=0.2, poll_interval=0.05)
+    target = tmp_path / "shared.txt"
+    target.write_text("data", encoding="utf-8")
+
+    event = threading.Event()
+
+    def _holder():
+        with manager.acquire([target]):
+            event.set()
+            time.sleep(0.5)
+
+    thread = threading.Thread(target=_holder)
+    thread.start()
+    event.wait(timeout=1)
+
+    with pytest.raises(FileLockAcquisitionError):
+        with manager.acquire([target], timeout=0.1):
+            pass
+
+    thread.join()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,60 @@
+import json
+from datetime import datetime
+
+try:
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - FastAPI not installed
+    TestClient = None
+
+from douglas.dashboard.server import create_app, render_static_dashboard
+
+
+def _seed_state(root):
+    features_dir = root / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    (features_dir / "feat1.yaml").write_text("status: in_progress\n", encoding="utf-8")
+    (features_dir / "feat2.yaml").write_text("status: finished\n", encoding="utf-8")
+
+    inbox_dir = root / "inbox"
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    (inbox_dir / "question1.yaml").write_text("question: foo\n", encoding="utf-8")
+    (inbox_dir / "question2.yaml").write_text("question: bar\nanswer: baz\n", encoding="utf-8")
+
+    state_dir = root / ".douglas" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    history = [
+        {"date": datetime.utcnow().isoformat(), "remaining": 5, "completed": 2},
+    ]
+    (state_dir / "sprint_history.json").write_text(json.dumps(history), encoding="utf-8")
+    flow = {"in_progress": [{"date": datetime.utcnow().isoformat(), "count": 2}]}
+    (state_dir / "cumulative_flow.json").write_text(json.dumps(flow), encoding="utf-8")
+
+
+def test_dashboard_api_endpoints(tmp_path):
+    _seed_state(tmp_path)
+    app = create_app(tmp_path)
+    if TestClient is not None:
+        client = TestClient(app)
+        summary = client.get("/api/summary").json()
+        burndown = client.get("/api/burndown").json()
+        flow = client.get("/api/cumulative-flow").json()
+    else:
+        summary = app.api_summary()
+        burndown = app.api_burndown()
+        flow = app.api_cumulative_flow()
+
+    assert summary["counts"]["features"]["in_progress"] == 1
+    assert summary["counts"]["features"]["finished"] == 1
+    assert summary["inbox"] == {"unanswered": 1, "answered": 1}
+    assert len(burndown) == 1
+    assert "in_progress" in flow
+
+
+def test_render_static_dashboard(tmp_path):
+    _seed_state(tmp_path)
+    output = tmp_path / "dashboard"
+    target = render_static_dashboard(tmp_path, output)
+    assert target.exists()
+    contents = target.read_text(encoding="utf-8")
+    assert "__DASHBOARD_PAYLOAD__" not in contents
+    assert "features" in contents

--- a/tests/test_demo_runner.py
+++ b/tests/test_demo_runner.py
@@ -1,0 +1,64 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from douglas.demo.runner import DemoRunner
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        body = json.dumps({"status": "ok"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: D401, A003 - silence test server logs
+        return
+
+
+def test_demo_runner_executes_steps(tmp_path):
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_port
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    script_path = tmp_path / "demo.yaml"
+    script_path.write_text(
+        f"""
+name: test-demo
+steps:
+  - name: Hello world
+    type: cli
+    command: ["python", "-c", "print('hi')"]
+  - name: Ping API
+    type: api
+    request:
+      method: GET
+      url: "http://127.0.0.1:{port}/"
+  - name: GUI placeholder
+    type: gui
+    script: tests/gui_walkthrough.py
+""",
+        encoding="utf-8",
+    )
+
+    runner = DemoRunner(workspace=tmp_path / "workspace")
+    try:
+        report = runner.run(script_path)
+    finally:
+        server.shutdown()
+        thread.join()
+
+    assert report.name == "test-demo"
+    assert len(report.steps) == 3
+    assert report.steps[0].status == "ok"
+    assert report.steps[1].status == "ok"
+    assert report.steps[2].status == "ok"
+
+    report_json = report.artifacts_dir / "report.json"
+    assert report_json.exists()
+    payload = json.loads(report_json.read_text(encoding="utf-8"))
+    assert payload["name"] == "test-demo"
+    assert payload["steps"][1]["metadata"]["status"] == 200

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -1,0 +1,67 @@
+import importlib
+import json
+import logging
+
+import pytest
+
+import douglas.logging as logging_module
+from douglas.logging import get_logger, log_action, log_exceptions
+
+
+@pytest.fixture(autouse=True)
+def _reload_logging_module():
+    importlib.reload(logging_module)
+    yield
+    importlib.reload(logging_module)
+
+
+def test_configure_logging_writes_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOUGLAS_LOG_DIR", str(tmp_path))
+    logging_module.configure_logging(level="info")
+    logger = get_logger("tests.logging")
+    logger.info("structured message", extra={"metadata": {"key": "value"}})
+    for handler in logging.getLogger("douglas").handlers:
+        handler.flush()
+    logging.shutdown()
+    log_file = tmp_path / "douglas.log"
+    contents = log_file.read_text(encoding="utf-8").strip().splitlines()
+    payload = json.loads(contents[-1])
+    assert payload["message"] == "structured message"
+    assert payload["metadata"]["key"] == "value"
+    assert payload["level"] == "INFO"
+
+
+def test_log_action_decorator_logs_success(caplog):
+    logging_module.configure_logging()
+    logger = get_logger("tests.actions")
+    base_logger = logging.getLogger("douglas")
+    previous = base_logger.propagate
+    base_logger.propagate = True
+    caplog.set_level("INFO", logger=logger.name)
+
+    @log_action("sample-action", logger_factory=lambda: logger)
+    def _run():
+        return "ok"
+
+    result = _run()
+    assert result == "ok"
+    output = caplog.text
+    assert "sample-action:start" in output
+    assert "sample-action:success" in output
+    base_logger.propagate = previous
+
+
+def test_log_exceptions_records_errors(caplog):
+    logging_module.configure_logging()
+    logger = get_logger("tests.exceptions")
+    base_logger = logging.getLogger("douglas")
+    previous = base_logger.propagate
+    base_logger.propagate = True
+    caplog.set_level("ERROR", logger=logger.name)
+
+    with pytest.raises(RuntimeError):
+        with log_exceptions(logger):
+            raise RuntimeError("boom")
+
+    assert "Unhandled error" in caplog.text
+    base_logger.propagate = previous


### PR DESCRIPTION
## Summary
- add structured logging module with rotating JSON file output, console formatting, and decorator helpers; update README documentation
- introduce agent workspaces, file locking, and merger utilities and wire Codex provider and CLI to support parallel execution
- build dashboard data loader and server (with static renderer), create demo runner DSL, and document/ship example demo plus targeted unit tests

## Testing
- `pytest tests/test_logging_module.py tests/test_agent_locking.py tests/test_dashboard.py tests/test_demo_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68d58005ea648326ab839c0ef0b343ca