### PR TITLE
Add Ruff formatter hook to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
 - repo: https://github.com/pycqa/ruff
   rev: stable
   hooks:
+    - id: ruff-format
     - id: ruff
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v5.10.1


### PR DESCRIPTION
## Summary
- add the Ruff formatting hook alongside the existing Ruff lint hook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d634d2f7e08326ab8d8f92058295d0