### PR TITLE
Add deterministic sprint zero backlog step

### DIFF
--- a/douglas/domain/__init__.py
+++ b/douglas/domain/__init__.py
@@ -1,0 +1,17 @@
+"""Domain models for Sprint Zero backlog primitives."""
+
+from .backlog import (
+    Epic,
+    Feature,
+    Story,
+    render_backlog_markdown,
+    serialize_backlog,
+)
+
+__all__ = [
+    "Epic",
+    "Feature",
+    "Story",
+    "render_backlog_markdown",
+    "serialize_backlog",
+]

--- a/douglas/domain/backlog.py
+++ b/douglas/domain/backlog.py
@@ -1,0 +1,240 @@
+"""Backlog domain models used for Sprint Zero planning."""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "Epic",
+    "Feature",
+    "Story",
+    "render_backlog_markdown",
+    "serialize_backlog",
+]
+
+
+def _slugify(value: str, *, prefix: str, index: int) -> str:
+    cleaned = "".join(ch for ch in value.lower() if ch.isalnum())
+    if not cleaned:
+        cleaned = f"{prefix}{index}"
+    return f"{prefix}-{cleaned[:12]}"
+
+
+def _coerce_identifier(
+    candidate: object, *, fallback_name: str, prefix: str, index: int
+) -> str:
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    name = fallback_name.strip() or f"{prefix.title()} {index}"
+    return _slugify(name, prefix=prefix, index=index)
+
+
+def _coerce_text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _coerce_criteria(value: object) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, Sequence):
+        results: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                text = item.strip()
+                if text:
+                    results.append(text)
+            elif item is not None:
+                rendered = str(item).strip()
+                if rendered:
+                    results.append(rendered)
+        return results
+    return []
+
+
+@dataclass(frozen=True)
+class Epic:
+    """Represents an epic generated during Sprint Zero."""
+
+    identifier: str
+    title: str
+    description: str = ""
+
+    @staticmethod
+    def from_mapping(data: Mapping[str, object], *, index: int) -> "Epic":
+        title = _coerce_text(data.get("title") or data.get("name") or "")
+        identifier = _coerce_identifier(
+            data.get("id") or data.get("identifier"),
+            fallback_name=title or "Epic",
+            prefix="epic",
+            index=index,
+        )
+        description = _coerce_text(
+            data.get("description") or data.get("summary") or ""
+        )
+        return Epic(identifier=identifier, title=title or identifier, description=description)
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        return {
+            "id": self.identifier,
+            "title": self.title,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True)
+class Feature:
+    """Represents a feature aligned to an epic."""
+
+    identifier: str
+    title: str
+    epic_id: str
+    description: str = ""
+    acceptance_criteria: tuple[str, ...] = field(default_factory=tuple)
+
+    @staticmethod
+    def from_mapping(
+        data: Mapping[str, object], *, index: int, default_epic_id: str
+    ) -> "Feature":
+        title = _coerce_text(data.get("title") or data.get("name") or "")
+        identifier = _coerce_identifier(
+            data.get("id") or data.get("identifier"),
+            fallback_name=title or "Feature",
+            prefix="feature",
+            index=index,
+        )
+        epic_id = _coerce_text(
+            data.get("epic_id") or data.get("epic") or default_epic_id
+        )
+        description = _coerce_text(
+            data.get("description") or data.get("summary") or ""
+        )
+        criteria = tuple(_coerce_criteria(data.get("acceptance_criteria")))
+        return Feature(
+            identifier=identifier,
+            title=title or identifier,
+            epic_id=epic_id,
+            description=description,
+            acceptance_criteria=criteria,
+        )
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "id": self.identifier,
+            "title": self.title,
+            "description": self.description,
+            "epic_id": self.epic_id,
+        }
+        if self.acceptance_criteria:
+            payload["acceptance_criteria"] = list(self.acceptance_criteria)
+        return payload
+
+
+@dataclass(frozen=True)
+class Story:
+    """Represents a user story aligned to a feature."""
+
+    identifier: str
+    title: str
+    feature_id: str
+    description: str = ""
+    acceptance_criteria: tuple[str, ...] = field(default_factory=tuple)
+
+    @staticmethod
+    def from_mapping(
+        data: Mapping[str, object], *, index: int, default_feature_id: str
+    ) -> "Story":
+        title = _coerce_text(data.get("title") or data.get("name") or "")
+        identifier = _coerce_identifier(
+            data.get("id") or data.get("identifier"),
+            fallback_name=title or "Story",
+            prefix="story",
+            index=index,
+        )
+        feature_id = _coerce_text(
+            data.get("feature_id")
+            or data.get("feature")
+            or data.get("featureId")
+            or default_feature_id
+        )
+        description = _coerce_text(
+            data.get("description") or data.get("summary") or ""
+        )
+        criteria = tuple(_coerce_criteria(data.get("acceptance_criteria")))
+        return Story(
+            identifier=identifier,
+            title=title or identifier,
+            feature_id=feature_id,
+            description=description,
+            acceptance_criteria=criteria,
+        )
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "id": self.identifier,
+            "title": self.title,
+            "description": self.description,
+            "feature_id": self.feature_id,
+        }
+        if self.acceptance_criteria:
+            payload["acceptance_criteria"] = list(self.acceptance_criteria)
+        return payload
+
+
+def serialize_backlog(
+    epics: Iterable[Epic],
+    features: Iterable[Feature],
+    stories: Iterable[Story],
+) -> MutableMapping[str, object]:
+    return {
+        "epics": [epic.to_dict() for epic in epics],
+        "features": [feature.to_dict() for feature in features],
+        "stories": [story.to_dict() for story in stories],
+    }
+
+
+def _group_by(items: Iterable, key_attr: str) -> dict[str, list]:
+    grouped: dict[str, list] = {}
+    for item in items:
+        key = getattr(item, key_attr)
+        grouped.setdefault(key, []).append(item)
+    return grouped
+
+
+def render_backlog_markdown(
+    project_name: str,
+    epics: Sequence[Epic],
+    features: Sequence[Feature],
+    stories: Sequence[Story],
+) -> str:
+    if not project_name:
+        project_name = "Sprint Zero"
+    lines: list[str] = [f"# {project_name} – Sprint Zero Backlog", ""]
+    features_by_epic = _group_by(features, "epic_id")
+    stories_by_feature = _group_by(stories, "feature_id")
+
+    for epic in epics:
+        lines.append(f"## {epic.title} ({epic.identifier})")
+        if epic.description:
+            lines.append(epic.description)
+        epic_features = features_by_epic.get(epic.identifier, [])
+        if epic_features:
+            for feature in epic_features:
+                lines.append(f"- **{feature.title}** ({feature.identifier})")
+                if feature.description:
+                    lines.append(textwrap.indent(feature.description, "  "))
+                story_entries = stories_by_feature.get(feature.identifier, [])
+                for story in story_entries:
+                    lines.append(
+                        f"  - {story.title} ({story.identifier})"
+                    )
+                    if story.description:
+                        lines.append(textwrap.indent(story.description, "    "))
+        lines.append("")
+
+    rendered = "\n".join(lines).strip()
+    return rendered + "\n"

--- a/douglas/steps/__init__.py
+++ b/douglas/steps/__init__.py
@@ -1,0 +1,5 @@
+"""Step helpers for Douglas workflows."""
+
+from .sprint_zero import SprintZeroContext, StepResult, run_sprint_zero
+
+__all__ = ["SprintZeroContext", "StepResult", "run_sprint_zero"]

--- a/douglas/steps/sprint_zero.py
+++ b/douglas/steps/sprint_zero.py
@@ -1,0 +1,245 @@
+"""Sprint Zero backlog scaffolding step."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+from douglas.domain.backlog import (
+    Epic,
+    Feature,
+    Story,
+    render_backlog_markdown,
+    serialize_backlog,
+)
+from douglas.providers.llm_provider import LLMProvider
+
+__all__ = ["SprintZeroContext", "StepResult", "run_sprint_zero"]
+
+
+def _normalize_prompt(prompt: str) -> str:
+    return " ".join(prompt.strip().split())
+
+
+def _hash_prompt(prompt: str) -> str:
+    return hashlib.sha256(_normalize_prompt(prompt).encode("utf-8")).hexdigest()
+
+
+def _ci_stub(project_name: str) -> str:
+    name = project_name.strip() or "Sprint Zero"
+    return textwrap.dedent(
+        f"""name: {name} CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Sprint Zero placeholder
+        run: echo \"Sprint Zero generated initial workflow\"
+"""
+    )
+
+
+def _coerce_artifacts(value: Mapping[str, object]) -> Dict[str, str]:
+    artifacts: Dict[str, str] = {}
+    for key, raw_content in value.items():
+        path = str(key)
+        if not path:
+            continue
+        if isinstance(raw_content, str):
+            content = raw_content
+        else:
+            content = json.dumps(raw_content, indent=2, sort_keys=True)
+        if not content.endswith("\n"):
+            content += "\n"
+        artifacts[path] = content
+    return artifacts
+
+
+@dataclass
+class SprintZeroContext:
+    project_root: Path
+    project_name: str
+    project_description: str
+    agent_label: str
+    seed: int
+    llm: Optional[LLMProvider] = None
+    step_name: str = "sprint_zero"
+    prompt: Optional[str] = None
+    backlog_state_path: Path = field(
+        default_factory=lambda: Path(".douglas/state/backlog.json")
+    )
+    backlog_markdown_path: Path = field(
+        default_factory=lambda: Path("ai-inbox/backlog.md")
+    )
+    ci_config_path: Path = field(
+        default_factory=lambda: Path(".github/workflows/app.yml")
+    )
+
+
+@dataclass(eq=True)
+class StepResult:
+    epics: list[Epic]
+    features: list[Feature]
+    stories: list[Story]
+    artifacts: Dict[str, str]
+    prompt: str
+    prompt_hash: str
+    seed: int
+    raw_response: str | None = None
+
+    def persist(self, project_root: Path) -> None:
+        for relative_path, content in self.artifacts.items():
+            path = Path(relative_path)
+            if not path.is_absolute():
+                path = project_root / path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+
+
+def _build_prompt(context: SprintZeroContext) -> str:
+    description = context.project_description.strip()
+    if not description:
+        description = "No project description provided."
+    return textwrap.dedent(
+        f"""You are {context.agent_label} planning Sprint Zero backlog for {context.project_name}.
+
+Project description:
+{description}
+
+Return JSON with keys: epics, features, stories, artifacts. Each epic should reference features and each feature should reference stories via identifiers.
+Artifacts must include '.douglas/state/backlog.json' and 'ai-inbox/backlog.md'.
+"""
+    ).strip()
+
+
+def _ensure_backlog_entries(payload: Mapping[str, object]) -> tuple[list[Mapping[str, object]], list[Mapping[str, object]], list[Mapping[str, object]]]:
+    epics_raw = []
+    features_raw = []
+    stories_raw = []
+    raw_epics = payload.get("epics")
+    if isinstance(raw_epics, list):
+        epics_raw = [item for item in raw_epics if isinstance(item, Mapping)]
+    raw_features = payload.get("features")
+    if isinstance(raw_features, list):
+        features_raw = [item for item in raw_features if isinstance(item, Mapping)]
+    raw_stories = payload.get("stories")
+    if isinstance(raw_stories, list):
+        stories_raw = [item for item in raw_stories if isinstance(item, Mapping)]
+    return epics_raw, features_raw, stories_raw
+
+
+def _resolve_provider(context: SprintZeroContext) -> Optional[LLMProvider]:
+    provider = context.llm
+    if provider is None:
+        return None
+    if hasattr(provider, "with_context"):
+        contextual = provider.with_context(context.agent_label, context.step_name)
+        if isinstance(contextual, LLMProvider):
+            return contextual
+    return provider
+
+
+def run_sprint_zero(context: SprintZeroContext) -> StepResult:
+    prompt = context.prompt.strip() if context.prompt else _build_prompt(context)
+    prompt_hash = _hash_prompt(prompt)
+    provider = _resolve_provider(context)
+    if provider is None:
+        raise ValueError("Sprint Zero requires an LLM provider.")
+
+    raw_response = provider.generate_code(prompt)
+    if not isinstance(raw_response, str):
+        raise ValueError("Sprint Zero provider must return textual JSON output.")
+
+    try:
+        payload = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Sprint Zero provider returned invalid JSON.") from exc
+
+    epics_raw, features_raw, stories_raw = _ensure_backlog_entries(payload)
+    epics = [Epic.from_mapping(item, index=index + 1) for index, item in enumerate(epics_raw)]
+    features: list[Feature] = []
+    for index, item in enumerate(features_raw):
+        epic_id = str(
+            item.get("epic_id")
+            or item.get("epic")
+            or item.get("epicId")
+            or ""
+        )
+        features.append(
+            Feature.from_mapping(
+                item,
+                index=index + 1,
+                default_epic_id=epic_id,
+            )
+        )
+
+    stories: list[Story] = []
+    for index, item in enumerate(stories_raw):
+        feature_id = str(
+            item.get("feature_id")
+            or item.get("feature")
+            or item.get("featureId")
+            or ""
+        )
+        stories.append(
+            Story.from_mapping(
+                item,
+                index=index + 1,
+                default_feature_id=feature_id,
+            )
+        )
+
+    artifacts_payload = payload.get("artifacts")
+    artifacts: Dict[str, str] = {}
+    if isinstance(artifacts_payload, Mapping):
+        artifacts = _coerce_artifacts(artifacts_payload)
+
+    backlog_dict = serialize_backlog(epics, features, stories)
+    backlog_json = json.dumps(backlog_dict, indent=2, sort_keys=True) + "\n"
+    artifacts.setdefault(context.backlog_state_path.as_posix(), backlog_json)
+
+    backlog_markdown = render_backlog_markdown(
+        context.project_name,
+        epics,
+        features,
+        stories,
+    )
+    artifacts.setdefault(context.backlog_markdown_path.as_posix(), backlog_markdown)
+
+    artifacts.setdefault(
+        context.ci_config_path.as_posix(),
+        _ci_stub(context.project_name),
+    )
+
+    metadata = payload.get("metadata")
+    seed = context.seed
+    recorded_hash = prompt_hash
+    if isinstance(metadata, Mapping):
+        meta_seed = metadata.get("seed")
+        if isinstance(meta_seed, int):
+            seed = meta_seed
+        meta_hash = metadata.get("prompt_hash")
+        if isinstance(meta_hash, str) and meta_hash:
+            recorded_hash = meta_hash
+
+    result = StepResult(
+        epics=epics,
+        features=features,
+        stories=stories,
+        artifacts=artifacts,
+        prompt=prompt,
+        prompt_hash=recorded_hash,
+        seed=seed,
+        raw_response=raw_response,
+    )
+    result.persist(context.project_root)
+    return result

--- a/tests/integration/test_sprint_zero_offline.py
+++ b/tests/integration/test_sprint_zero_offline.py
@@ -1,0 +1,123 @@
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import yaml
+
+from douglas.providers.mock_provider import DeterministicMockProvider
+from douglas.providers.replay_provider import (
+    CassetteRecordingProvider,
+    CassetteStore,
+    ReplayProvider,
+    compute_project_fingerprint,
+)
+from douglas.steps.sprint_zero import SprintZeroContext, run_sprint_zero
+
+from tests.integration.test_offline_sprint_zero import _prepare_project
+
+
+def _load_project_metadata(project_dir: Path) -> tuple[str, str, int, dict]:
+    config_path = project_dir / "douglas.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    project = config.get("project", {}) if isinstance(config, dict) else {}
+    ai = config.get("ai", {}) if isinstance(config, dict) else {}
+    name = str(project.get("name", project_dir.name))
+    description = str(project.get("description", ""))
+    seed = int(ai.get("seed", 0))
+    return name, description, seed, ai
+
+
+def _baseline_context(project_dir: Path) -> SprintZeroContext:
+    name, description, seed, _ = _load_project_metadata(project_dir)
+    provider = DeterministicMockProvider(project_root=project_dir, seed=seed)
+    return SprintZeroContext(
+        project_root=project_dir,
+        project_name=name,
+        project_description=description,
+        agent_label="ProductOwner",
+        seed=seed,
+        llm=provider,
+    )
+
+
+def test_sprint_zero_deterministic_backlog(tmp_path):
+    project_dir = _prepare_project(tmp_path)
+    context = _baseline_context(project_dir)
+
+    first_result = run_sprint_zero(context)
+
+    backlog_json_path = project_dir / ".douglas" / "state" / "backlog.json"
+    backlog_md_path = project_dir / "ai-inbox" / "backlog.md"
+    ci_path = project_dir / ".github" / "workflows" / "app.yml"
+
+    assert backlog_json_path.exists()
+    assert backlog_md_path.exists()
+    assert ci_path.exists()
+
+    backlog_json = backlog_json_path.read_text(encoding="utf-8")
+    backlog_md = backlog_md_path.read_text(encoding="utf-8")
+    ci_yaml = ci_path.read_text(encoding="utf-8")
+
+    assert first_result.epics
+    assert first_result.features
+    assert first_result.stories
+
+    second_context = _baseline_context(project_dir)
+    second_result = run_sprint_zero(second_context)
+
+    assert first_result == second_result
+    assert backlog_json_path.read_text(encoding="utf-8") == backlog_json
+    assert backlog_md_path.read_text(encoding="utf-8") == backlog_md
+    assert ci_path.read_text(encoding="utf-8") == ci_yaml
+
+    payload = json.loads(backlog_json)
+    assert len(payload.get("epics", [])) == len(first_result.epics)
+
+
+def test_sprint_zero_replay_round_trip(tmp_path):
+    project_dir = _prepare_project(tmp_path)
+    name, description, seed, ai_config = _load_project_metadata(project_dir)
+    cassette_dir = project_dir / ".douglas" / "cassettes"
+    store = CassetteStore(cassette_dir)
+    fingerprint = compute_project_fingerprint(project_dir, ai_config)
+
+    recording_provider = CassetteRecordingProvider(
+        DeterministicMockProvider(project_root=project_dir, seed=seed),
+        store=store,
+        provider_name="mock",
+        model_name=None,
+        project_fingerprint=fingerprint,
+        base_seed=seed,
+    )
+    record_context = SprintZeroContext(
+        project_root=project_dir,
+        project_name=name,
+        project_description=description,
+        agent_label="ProductOwner",
+        seed=seed,
+        llm=recording_provider,
+    )
+
+    recorded_result = run_sprint_zero(record_context)
+
+    replay_provider = ReplayProvider(
+        store=store,
+        project_root=project_dir,
+        project_fingerprint=fingerprint,
+        base_seed=seed,
+        model_name=None,
+        provider_name="mock",
+    )
+    replay_context = replace(record_context, llm=replay_provider)
+    replay_result = run_sprint_zero(replay_context)
+
+    assert replay_result == recorded_result
+
+    backlog_path = project_dir / ".douglas" / "state" / "backlog.json"
+    replay_payload = json.loads(backlog_path.read_text(encoding="utf-8"))
+    assert replay_payload.get("epics")


### PR DESCRIPTION
## Summary
- add backlog domain models for epics, features, and stories used by Sprint Zero
- implement a Sprint Zero step that emits deterministic artifacts and writes backlog/CI scaffolding
- extend the deterministic mock provider and offline integration tests to cover Sprint Zero and replay determinism

## Testing
- pytest tests/integration/test_sprint_zero_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e2df718c83269577cf2b00bddebc